### PR TITLE
Propagate unhandled errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "rust-analyzer.linkedProjects": [
-        "Cargo.toml",
+        // "Cargo.toml",
         "examples/embassy-nucleo-h563zi/Cargo.toml",
-        "examples/embassy-stm32-g431cb/Cargo.toml",
+        // "examples/embassy-stm32-g431cb/Cargo.toml",
     ]
 }

--- a/examples/embassy-nucleo-h563zi/src/power.rs
+++ b/examples/embassy-nucleo-h563zi/src/power.rs
@@ -1,5 +1,5 @@
 //! Handles USB PD negotiation.
-use defmt::{info, Format};
+use defmt::{info, warn, Format};
 use embassy_futures::select::{select, Either};
 use embassy_stm32::gpio::Output;
 use embassy_stm32::ucpd::{self, CcPhy, CcPull, CcSel, CcVState, PdPhy, Ucpd};
@@ -197,7 +197,7 @@ pub async fn ucpd_task(mut ucpd_resources: UcpdResources) {
         ucpd_resources.led_yellow.set_high();
 
         match select(sink.run(), wait_detached(&mut cc_phy)).await {
-            Either::First(_) => (),
+            Either::First(result) => warn!("Sink loop broken with result: {}", result),
             Either::Second(_) => {
                 info!("Detached");
                 continue;

--- a/examples/embassy-stm32-g431cb/Cargo.toml
+++ b/examples/embassy-stm32-g431cb/Cargo.toml
@@ -38,7 +38,7 @@ static_cell = "2"
 micromath = "2.1.0"
 
 uom = { version = "0.36.0", default-features = false, features = ["si", "f32"] }
-usbpd = { path = "../../usbpd" }
+usbpd = { path = "../../usbpd", features = ["defmt"] }
 
 # cargo build/run
 [profile.dev]

--- a/examples/embassy-stm32-g431cb/src/power.rs
+++ b/examples/embassy-stm32-g431cb/src/power.rs
@@ -1,5 +1,5 @@
 //! Handles USB PD negotiation.
-use defmt::{info, Format};
+use defmt::{info, Format, warn};
 use embassy_futures::select::{select, Either};
 use embassy_stm32::gpio::Output;
 use embassy_stm32::ucpd::{self, CcPhy, CcPull, CcSel, CcVState, PdPhy, Ucpd};

--- a/examples/embassy-stm32-g431cb/src/power.rs
+++ b/examples/embassy-stm32-g431cb/src/power.rs
@@ -156,9 +156,9 @@ pub async fn ucpd_task(mut ucpd_resources: UcpdResources) {
         info!("Run sink");
 
         match select(sink.run(), wait_detached(&mut cc_phy)).await {
-            Either::First(_) => (),
+            Either::First(result) => warn!("Sink loop broken with result: {}", result),
             Either::Second(_) => {
-                info!("USB cable detached");
+                info!("Detached");
                 continue;
             }
         }

--- a/usbpd/Cargo.toml
+++ b/usbpd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usbpd"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Adrian Figueroa <elagil@takanome.de>"]
 edition = "2021"
 description = "USB-PD library for `[no_std]`."

--- a/usbpd/src/protocol_layer/mod.rs
+++ b/usbpd/src/protocol_layer/mod.rs
@@ -34,7 +34,7 @@ const MAX_MESSAGE_SIZE: usize = 30;
 /// Errors that can occur in the protocol layer.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub(crate) enum Error {
+pub enum Error {
     /// Port partner requested soft reset.
     SoftReset,
     /// Driver reported a hard reset.


### PR DESCRIPTION
For example, when a source is unresponsive after multiple hard resets.
The user application can then disconnect/reconnect or perform some other activity.