### PR TITLE
fix compilation with log feature flag

### DIFF
--- a/usbpd/src/protocol_layer/message/mod.rs
+++ b/usbpd/src/protocol_layer/message/mod.rs
@@ -233,7 +233,7 @@ impl Message {
                     return message;
                 }
                 let num_obj = message.header.num_objects();
-                trace!("VENDOR: {:?}, {:?}, {:x}", len, num_obj, payload);
+                trace!("VENDOR: {:?}, {:?}, {:?}", len, num_obj, payload);
 
                 let header = {
                     let raw = VDMHeaderRaw(LittleEndian::read_u32(&payload[..4]));

--- a/usbpd/src/protocol_layer/message/request.rs
+++ b/usbpd/src/protocol_layer/message/request.rs
@@ -268,7 +268,7 @@ impl PowerSource {
     ) -> Option<(usize, &pdo::Augmented)> {
         for (index, cap) in source_capabilities.pdos().iter().enumerate() {
             let pdo::PowerDataObject::Augmented(augmented) = cap else {
-                trace!("Skip non-augmented PDO {}", cap);
+                trace!("Skip non-augmented PDO {:?}", cap);
                 continue;
             };
 
@@ -278,10 +278,10 @@ impl PowerSource {
                     if spr.min_voltage() <= voltage && spr.max_voltage() >= voltage {
                         return Some((index, augmented));
                     } else {
-                        trace!("Skip PDO, voltage out of range. {}", augmented);
+                        trace!("Skip PDO, voltage out of range. {:?}", augmented);
                     }
                 }
-                _ => trace!("Skip PDO, only SPR is supported. {}", augmented),
+                _ => trace!("Skip PDO, only SPR is supported. {:?}", augmented),
             };
         }
 

--- a/usbpd/src/protocol_layer/mod.rs
+++ b/usbpd/src/protocol_layer/mod.rs
@@ -224,7 +224,7 @@ impl<DRIVER: Driver, TIMER: Timer> ProtocolLayer<DRIVER, TIMER> {
             MessageType::Control(ControlMessageType::GoodCRC)
         );
 
-        trace!("Transmit message: {}", message);
+        trace!("Transmit message: {:?}", message);
         self.counters.retry.reset();
 
         let mut buffer = Self::get_message_buffer();
@@ -287,14 +287,14 @@ impl<DRIVER: Driver, TIMER: Timer> ProtocolLayer<DRIVER, TIMER> {
 
             match message.header.message_type() {
                 MessageType::Control(ControlMessageType::Reserved) | MessageType::Data(DataMessageType::Reserved) => {
-                    trace!("Unsupported message type in header: {}", message.header);
+                    trace!("Unsupported message type in header: {:?}", message.header);
                     return Err(RxError::UnsupportedMessage);
                 }
                 MessageType::Control(ControlMessageType::SoftReset) => return Err(RxError::SoftReset),
                 _ => (),
             }
 
-            trace!("Received message {}", message);
+            trace!("Received message {:?}", message);
             return Ok(message);
         }
     }

--- a/usbpd/src/sink/policy_engine.rs
+++ b/usbpd/src/sink/policy_engine.rs
@@ -159,7 +159,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
 
                 // Attempt to recover protocol errors with a soft reset.
                 (_, error) => {
-                    error!("Protocol error {} in sink state transition", error);
+                    error!("Protocol error {:?} in sink state transition", error);
                     None
                 }
             };
@@ -170,7 +170,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
 
             Ok(())
         } else {
-            error!("Unrecoverable result {} in sink state transition", result);
+            error!("Unrecoverable result {:?} in sink state transition", result);
             result
         }
     }
@@ -186,7 +186,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
 
     async fn wait_for_source_capabilities(&mut self) -> Result<SourceCapabilities, Error> {
         let message = self.protocol_layer.wait_for_source_capabilities().await?;
-        trace!("Source capabilities: {}", message);
+        trace!("Source capabilities: {:?}", message);
 
         let Some(Data::SourceCapabilities(capabilities)) = message.data else {
             unreachable!()


### PR DESCRIPTION
withot this fix usbpd can't compile with this feature flag

```
cargo build --features log  
   Compiling usbpd v1.0.1 (/home/okhsunrog/code/rust/usbpd/usbpd)
error[E0277]: `Message` doesn't implement `Display`
   --> src/protocol_layer/mod.rs:227:40
    |
227 |         trace!("Transmit message: {}", message);
    |                                        ^^^^^^^ `Message` cannot be formatted with the default formatter
    |
    = help: the trait `Display` is not implemented for `Message`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `trace` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: `Header` doesn't implement `Display`
   --> src/protocol_layer/mod.rs:290:70
    |
290 |                     trace!("Unsupported message type in header: {}", message.header);
    |                                                                      ^^^^^^^^^^^^^^ `Header` cannot be formatted with the default formatter
    |
    = help: the trait `Display` is not implemented for `Header`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `trace` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: `Message` doesn't implement `Display`
   --> src/protocol_layer/mod.rs:297:43
    |
297 |             trace!("Received message {}", message);
    |                                           ^^^^^^^ `Message` cannot be formatted with the default formatter
    |
    = help: the trait `Display` is not implemented for `Message`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `trace` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: `protocol_layer::Error` doesn't implement `Display`
   --> src/sink/policy_engine.rs:162:74
    |
162 |                     error!("Protocol error {} in sink state transition", error);
    |                                                                          ^^^^^ `protocol_layer::Error` cannot be formatted with the default formatter
    |
    = help: the trait `Display` is not implemented for `protocol_layer::Error`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `error` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: `Result<(), policy_engine::Error>` doesn't implement `Display`
   --> src/sink/policy_engine.rs:173:72
    |
173 |             error!("Unrecoverable result {} in sink state transition", result);
    |                                                                        ^^^^^^ `Result<(), policy_engine::Error>` cannot be formatted with the default formatter
    |
    = help: the trait `Display` is not implemented for `Result<(), policy_engine::Error>`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `error` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: `Message` doesn't implement `Display`
   --> src/sink/policy_engine.rs:189:43
    |
189 |         trace!("Source capabilities: {}", message);
    |                                           ^^^^^^^ `Message` cannot be formatted with the default formatter
    |
    = help: the trait `Display` is not implemented for `Message`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `trace` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: `PowerDataObject` doesn't implement `Display`
   --> src/protocol_layer/message/request.rs:271:53
    |
271 |                 trace!("Skip non-augmented PDO {}", cap);
    |                                                     ^^^ `PowerDataObject` cannot be formatted with the default formatter
    |
    = help: the trait `Display` is not implemented for `PowerDataObject`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `trace` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: `Augmented` doesn't implement `Display`
   --> src/protocol_layer/message/request.rs:281:70
    |
281 |                         trace!("Skip PDO, voltage out of range. {}", augmented);
    |                                                                      ^^^^^^^^^ `Augmented` cannot be formatted with the default formatter
    |
    = help: the trait `Display` is not implemented for `Augmented`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `trace` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: `Augmented` doesn't implement `Display`
   --> src/protocol_layer/message/request.rs:284:68
    |
284 |                 _ => trace!("Skip PDO, only SPR is supported. {}", augmented),
    |                                                                    ^^^^^^^^^ `Augmented` cannot be formatted with the default formatter
    |
    = help: the trait `Display` is not implemented for `Augmented`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `trace` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `[u8]: LowerHex` is not satisfied
   --> src/protocol_layer/message/mod.rs:236:66
    |
236 |                 trace!("VENDOR: {:?}, {:?}, {:x}", len, num_obj, payload);
    |                                             ----                 ^^^^^^^ the trait `LowerHex` is not implemented for `[u8]`
    |                                             |
    |                                             required by a bound introduced by this call
    |
    = help: the following other types implement trait `LowerHex`:
              &T
              &mut T
              QuantityArguments<D, U, V, N>
              Wrapping<T>
              compiler_builtins::math::libm::support::hex_float::Hexf<(F, F)>
              compiler_builtins::math::libm::support::hex_float::Hexf<(F, i32)>
              compiler_builtins::math::libm::support::hex_float::Hexf<F>
              compiler_builtins::math::libm::support::hex_float::Hexf<i32>
            and 16 others
    = note: required for `&[u8]` to implement `LowerHex`
note: required by a bound in `core::fmt::rt::Argument::<'_>::new_lower_hex`
   --> /home/okhsunrog/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/rt.rs:132:29
    |
132 |     pub fn new_lower_hex<T: LowerHex>(x: &T) -> Argument<'_> {
    |                             ^^^^^^^^ required by this bound in `Argument::<'_>::new_lower_hex`
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `trace` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `usbpd` (lib) due to 10 previous errors

```