### PR TITLE
WIP: Make message parsing fallible

### DIFF
--- a/usbpd/src/protocol_layer/message/header.rs
+++ b/usbpd/src/protocol_layer/message/header.rs
@@ -72,10 +72,17 @@ impl Header {
         )
     }
 
-    pub fn from_bytes(buf: &[u8]) -> Self {
-        assert!(buf.len() == 2);
-
-        Header(LittleEndian::read_u16(buf))
+    pub fn from_bytes(buf: &[u8]) -> Result<Self, ParseError> {
+        if buf.len() != 2 {
+            return Err(ParseError::InvalidLength {
+                expected: 2,
+                found: buf.len(),
+            });
+        }
+        let header = Header(LittleEndian::read_u16(buf));
+        // Validate spec_revision
+        header.spec_revision()?;
+        Ok(header)
     }
 
     pub fn to_bytes(self, buf: &mut [u8]) -> usize {

--- a/usbpd/src/protocol_layer/message/header.rs
+++ b/usbpd/src/protocol_layer/message/header.rs
@@ -110,7 +110,7 @@ impl TryFrom<u8> for SpecificationRevision {
             0b00 => Ok(Self::R1_0),
             0b01 => Ok(Self::R2_0),
             0b10 => Ok(Self::R3_0),
-            _ => Err(ParseError::InvalidSpecificationRevision(value)),
+            _ => Err(ParseError::UnsupportedSpecificationRevision(value)),
         }
     }
 }

--- a/usbpd/src/protocol_layer/message/header.rs
+++ b/usbpd/src/protocol_layer/message/header.rs
@@ -73,12 +73,8 @@ impl Header {
     }
 
     pub fn from_bytes(buf: &[u8]) -> Result<Self, ParseError> {
-        if buf.len() != 2 {
-            return Err(ParseError::InvalidLength {
-                expected: 2,
-                found: buf.len(),
-            });
-        }
+        assert!(buf.len() == 2);
+
         let header = Header(LittleEndian::read_u16(buf));
         // Validate spec_revision
         header.spec_revision()?;

--- a/usbpd/src/protocol_layer/message/mod.rs
+++ b/usbpd/src/protocol_layer/message/mod.rs
@@ -294,8 +294,8 @@ pub enum ParseError {
         /// The actual length found.
         found: usize,
     },
-    /// The specification revision field was invalid.
-    InvalidSpecificationRevision(u8),
+    /// The specification revision field is not supported.
+    UnsupportedSpecificationRevision(u8),
     /// An unknown or reserved message type was encountered.
     InvalidMessageType(u8),
     /// An unknown or reserved data message type was encountered.

--- a/usbpd/src/protocol_layer/message/mod.rs
+++ b/usbpd/src/protocol_layer/message/mod.rs
@@ -279,3 +279,28 @@ impl Message {
         Self::from_bytes_with_state(data, &())
     }
 }
+
+/// Errors that can occur during message/header parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ParseError {
+    /// The input buffer has an invalid length.
+    /// * `expected` - The expected length.
+    /// * `found` - The actual length found.
+    InvalidLength {
+        /// The expected length.
+        expected: usize,
+        /// The actual length found.
+        found: usize,
+    },
+    /// The specification revision field was invalid.
+    InvalidSpecificationRevision(u8),
+    /// An unknown or reserved message type was encountered.
+    InvalidMessageType(u8),
+    /// An unknown or reserved data message type was encountered.
+    InvalidDataMessageType(u8),
+    /// An unknown or reserved control message type was encountered.
+    InvalidControlMessageType(u8),
+    /// Other parsing error with a message.
+    Other(&'static str),
+}

--- a/usbpd/src/protocol_layer/mod.rs
+++ b/usbpd/src/protocol_layer/mod.rs
@@ -286,7 +286,7 @@ impl<DRIVER: Driver, TIMER: Timer> ProtocolLayer<DRIVER, TIMER> {
                 Err(DriverRxError::HardReset) => return Err(RxError::HardReset),
             };
 
-            let message = Message::from_bytes(&buffer[..length]);
+            let message = Message::from_bytes(&buffer[..length])?;
 
             // Update specification revision, based on the received frame.
             self.default_header = self.default_header.with_spec_revision(message.header.spec_revision()?);

--- a/usbpd/src/protocol_layer/mod.rs
+++ b/usbpd/src/protocol_layer/mod.rs
@@ -93,6 +93,12 @@ impl From<TxError> for Error {
     }
 }
 
+impl From<crate::protocol_layer::message::ParseError> for RxError {
+    fn from(_err: crate::protocol_layer::message::ParseError) -> Self {
+        RxError::UnexpectedMessage // You can add a more specific variant if desired
+    }
+}
+
 #[derive(Debug)]
 struct Counters {
     _busy: Counter,
@@ -283,7 +289,7 @@ impl<DRIVER: Driver, TIMER: Timer> ProtocolLayer<DRIVER, TIMER> {
             let message = Message::from_bytes(&buffer[..length]);
 
             // Update specification revision, based on the received frame.
-            self.default_header = self.default_header.with_spec_revision(message.header.spec_revision());
+            self.default_header = self.default_header.with_spec_revision(message.header.spec_revision()?);
 
             match message.header.message_type() {
                 MessageType::Control(ControlMessageType::Reserved) | MessageType::Data(DataMessageType::Reserved) => {

--- a/usbpd/src/protocol_layer/mod.rs
+++ b/usbpd/src/protocol_layer/mod.rs
@@ -62,7 +62,7 @@ enum RxError {
     /// An unsupported message was received.
     UnsupportedMessage,
     /// An unexpected message was received.
-    UnexpectedMessage,
+    ParseError,
 }
 
 impl From<RxError> for Error {
@@ -72,7 +72,7 @@ impl From<RxError> for Error {
             RxError::HardReset => Error::HardReset,
             RxError::ReceiveTimeout => Error::ReceiveTimeout,
             RxError::UnsupportedMessage => Error::UnsupportedMessage,
-            RxError::UnexpectedMessage => Error::UnexpectedMessage,
+            RxError::ParseError => Error::UnexpectedMessage,
         }
     }
 }
@@ -95,7 +95,7 @@ impl From<TxError> for Error {
 
 impl From<crate::protocol_layer::message::ParseError> for RxError {
     fn from(_err: crate::protocol_layer::message::ParseError) -> Self {
-        RxError::UnexpectedMessage // You can add a more specific variant if desired
+        RxError::ParseError
     }
 }
 
@@ -191,10 +191,10 @@ impl<DRIVER: Driver, TIMER: Timer> ProtocolLayer<DRIVER, TIMER> {
                     Ok(())
                 } else {
                     // Wrong transmitted message was acknowledged.
-                    Err(RxError::UnexpectedMessage)
+                    Err(RxError::ParseError)
                 }
             } else {
-                Err(RxError::UnexpectedMessage)
+                Err(RxError::ParseError)
             }
         };
 
@@ -381,7 +381,7 @@ impl<DRIVER: Driver, TIMER: Timer> ProtocolLayer<DRIVER, TIMER> {
                             Err(Error::UnexpectedMessage)
                         };
                     }
-                    Err(RxError::UnexpectedMessage) => unreachable!(),
+                    Err(RxError::ParseError) => unreachable!(),
                     Err(other) => return Err(other.into()),
                 }
             }

--- a/usbpd/src/sink/policy_engine.rs
+++ b/usbpd/src/sink/policy_engine.rs
@@ -459,7 +459,7 @@ mod tests {
         // `WaitForCapabilities` -> `EvaluateCapabilities`
         policy_engine.run_step().await.unwrap();
 
-        let good_crc = Message::from_bytes(&policy_engine.protocol_layer.driver().probe_transmitted_data());
+        let good_crc = Message::from_bytes(&policy_engine.protocol_layer.driver().probe_transmitted_data()).unwrap();
         assert!(matches!(
             good_crc.header.message_type(),
             MessageType::Control(ControlMessageType::GoodCRC)
@@ -477,7 +477,8 @@ mod tests {
         // `SelectCapability` -> `TransitionSink`
         policy_engine.run_step().await.unwrap();
 
-        let request_capabilities = Message::from_bytes(&policy_engine.protocol_layer.driver().probe_transmitted_data());
+        let request_capabilities =
+            Message::from_bytes(&policy_engine.protocol_layer.driver().probe_transmitted_data()).unwrap();
         assert!(matches!(
             request_capabilities.header.message_type(),
             MessageType::Data(DataMessageType::Request)
@@ -491,7 +492,7 @@ mod tests {
 
         assert!(matches!(policy_engine.state, State::Ready));
 
-        let good_crc = Message::from_bytes(&policy_engine.protocol_layer.driver().probe_transmitted_data());
+        let good_crc = Message::from_bytes(&policy_engine.protocol_layer.driver().probe_transmitted_data()).unwrap();
         assert!(matches!(
             good_crc.header.message_type(),
             MessageType::Control(ControlMessageType::GoodCRC)


### PR DESCRIPTION
As discussed, trying to get rid of panicing branches and making the parsing more robust. This way we can use the parser for cases where PD packets can be invalid, without crashing the program.
I haven't cleaned all places, so WIP for now.
Is that okay to have Data::Unknown? I guess it can be left like that till the library doesn't cover full spec, when the parser and types cover the full spec, it can be removed and the parser would return an error in such case. What do you think?