### PR TITLE
Dual Role Port

### DIFF
--- a/examples/embassy-nucleo-h563zi/src/power.rs
+++ b/examples/embassy-nucleo-h563zi/src/power.rs
@@ -243,14 +243,14 @@ pub async fn ucpd_task(mut ucpd_resources: UcpdResources) {
             cc_sel,
         );
 
-        let mut driver = UcpdSinkDriver::new(pd_phy);
-        let mut device = Device {
+        let driver = UcpdSinkDriver::new(pd_phy);
+        let device = Device {
             source_capabilities: None,
             ticker: Ticker::every(Duration::from_secs(3)),
             test_capabilities: TestCapabilities::Safe5V,
             led: &mut ucpd_resources.led_red,
         };
-        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(&mut driver, &mut device);
+        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(driver, device);
         info!("Sink initialized");
 
         ucpd_resources.led_yellow.set_high();

--- a/examples/embassy-nucleo-h563zi/src/power.rs
+++ b/examples/embassy-nucleo-h563zi/src/power.rs
@@ -11,7 +11,9 @@ use panic_probe as _;
 use uom::si::electric_potential;
 use usbpd::protocol_layer::message::data::request::{self, CurrentRequest, VoltageRequest};
 use usbpd::protocol_layer::message::data::source_capabilities::SourceCapabilities;
-use usbpd::sink::device_policy_manager::{DevicePolicyManager, DrpDevicePolicyManager, EprDevicePolicyManager, Event, Info, SinkDpm};
+use usbpd::sink::device_policy_manager::{
+    DevicePolicyManager, DrpDevicePolicyManager, EprDevicePolicyManager, Event, Info, SinkDpm,
+};
 use usbpd::sink::policy_engine::Sink;
 use usbpd::timers::Timer as SinkTimer;
 use usbpd::units::ElectricPotential;
@@ -141,12 +143,12 @@ struct Device<'d> {
     source_capabilities: Option<SourceCapabilities>,
 }
 
-impl <'d> SinkDpm for Device<'d> {}
+impl<'d> SinkDpm for Device<'d> {}
 
 // This device does not have EPR or DRP capabilities, so
 // the trait implementations for both remain empty (default)
-impl <'d> DrpDevicePolicyManager for Device<'d> {}
-impl <'d> EprDevicePolicyManager for Device<'d> {}
+impl<'d> DrpDevicePolicyManager for Device<'d> {}
+impl<'d> EprDevicePolicyManager for Device<'d> {}
 
 impl DevicePolicyManager for Device<'_> {
     async fn inform(&mut self, source_capabilities: &SourceCapabilities, _info: Info) {

--- a/examples/embassy-nucleo-h563zi/src/power.rs
+++ b/examples/embassy-nucleo-h563zi/src/power.rs
@@ -11,7 +11,7 @@ use panic_probe as _;
 use uom::si::electric_potential;
 use usbpd::protocol_layer::message::data::request::{self, CurrentRequest, VoltageRequest};
 use usbpd::protocol_layer::message::data::source_capabilities::SourceCapabilities;
-use usbpd::sink::device_policy_manager::{DevicePolicyManager, Event};
+use usbpd::sink::device_policy_manager::{DevicePolicyManager, DrpDevicePolicyManager, EprDevicePolicyManager, Event, Info, SinkDpm};
 use usbpd::sink::policy_engine::Sink;
 use usbpd::timers::Timer as SinkTimer;
 use usbpd::units::ElectricPotential;
@@ -141,8 +141,15 @@ struct Device<'d> {
     source_capabilities: Option<SourceCapabilities>,
 }
 
+impl <'d> SinkDpm for Device<'d> {}
+
+// This device does not have EPR or DRP capabilities, so
+// the trait implementations for both remain empty (default)
+impl <'d> DrpDevicePolicyManager for Device<'d> {}
+impl <'d> EprDevicePolicyManager for Device<'d> {}
+
 impl DevicePolicyManager for Device<'_> {
-    async fn inform(&mut self, source_capabilities: &SourceCapabilities) {
+    async fn inform(&mut self, source_capabilities: &SourceCapabilities, _info: Info) {
         info!("New caps received {}", source_capabilities);
 
         self.source_capabilities = Some(source_capabilities.clone());
@@ -236,14 +243,14 @@ pub async fn ucpd_task(mut ucpd_resources: UcpdResources) {
             cc_sel,
         );
 
-        let driver = UcpdSinkDriver::new(pd_phy);
-        let device = Device {
+        let mut driver = UcpdSinkDriver::new(pd_phy);
+        let mut device = Device {
             source_capabilities: None,
             ticker: Ticker::every(Duration::from_secs(3)),
             test_capabilities: TestCapabilities::Safe5V,
             led: &mut ucpd_resources.led_red,
         };
-        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(driver, device);
+        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(&mut driver, &mut device);
         info!("Sink initialized");
 
         ucpd_resources.led_yellow.set_high();

--- a/examples/embassy-stm32-g431cb-epr/src/power.rs
+++ b/examples/embassy-stm32-g431cb-epr/src/power.rs
@@ -460,9 +460,9 @@ pub async fn ucpd_task(mut ucpd_resources: UcpdResources) {
             cc_sel,
         );
 
-        let mut driver = UcpdSinkDriver::new(pd_phy);
-        let mut device = Device::default();
-        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(&mut driver, &mut device);
+        let driver = UcpdSinkDriver::new(pd_phy);
+        let device = Device::default();
+        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(driver, device);
         info!("Run sink");
 
         match select(sink.run(), wait_detached(&mut cc_phy)).await {

--- a/examples/embassy-stm32-g431cb-epr/src/power.rs
+++ b/examples/embassy-stm32-g431cb-epr/src/power.rs
@@ -17,7 +17,9 @@ use usbpd::protocol_layer::message::data::request::{
     Avs, CurrentRequest, EprRequestDataObject, FixedVariableSupply, PowerSource, VoltageRequest,
 };
 use usbpd::protocol_layer::message::data::source_capabilities::{Augmented, PowerDataObject, SourceCapabilities};
-use usbpd::sink::device_policy_manager::{DevicePolicyManager, DrpDevicePolicyManager, EprDevicePolicyManager, Event, Info, SinkDpm};
+use usbpd::sink::device_policy_manager::{
+    DevicePolicyManager, DrpDevicePolicyManager, EprDevicePolicyManager, Event, Info, SinkDpm,
+};
 use usbpd::sink::policy_engine::Sink;
 use usbpd::timers::Timer as SinkTimer;
 use usbpd::units::Power;
@@ -256,7 +258,6 @@ impl EprDevicePolicyManager for Device {
         // A user could define custom behavior here to deal with this entry failure
     }
 }
-
 
 impl DevicePolicyManager for Device {
     async fn inform(&mut self, source_capabilities: &SourceCapabilities, _info: Info) {

--- a/examples/embassy-stm32-g431cb-epr/src/power.rs
+++ b/examples/embassy-stm32-g431cb-epr/src/power.rs
@@ -11,12 +11,13 @@ use uom::si::electric_potential::millivolt;
 use uom::si::power::{milliwatt, watt};
 #[cfg(not(feature = "avs"))]
 use usbpd::_50millivolts_mod::_50millivolts;
+use usbpd::protocol_layer::message::data::epr_mode;
 #[allow(unused_imports)] // Avs is used in AVS feature mode
 use usbpd::protocol_layer::message::data::request::{
     Avs, CurrentRequest, EprRequestDataObject, FixedVariableSupply, PowerSource, VoltageRequest,
 };
 use usbpd::protocol_layer::message::data::source_capabilities::{Augmented, PowerDataObject, SourceCapabilities};
-use usbpd::sink::device_policy_manager::{DevicePolicyManager, Event};
+use usbpd::sink::device_policy_manager::{DevicePolicyManager, DrpDevicePolicyManager, EprDevicePolicyManager, Event, Info, SinkDpm};
 use usbpd::sink::policy_engine::Sink;
 use usbpd::timers::Timer as SinkTimer;
 use usbpd::units::Power;
@@ -244,8 +245,21 @@ struct Device {
     entered_epr_mode: bool,
 }
 
+impl SinkDpm for Device {}
+
+// This is not a dual role port, so this implementation remains default
+impl DrpDevicePolicyManager for Device {}
+
+impl EprDevicePolicyManager for Device {
+    async fn epr_mode_entry_failed(&mut self, reason: epr_mode::DataEnterFailed) {
+        warn!("EPR mode entry failed! {:?}", &reason);
+        // A user could define custom behavior here to deal with this entry failure
+    }
+}
+
+
 impl DevicePolicyManager for Device {
-    async fn inform(&mut self, source_capabilities: &SourceCapabilities) {
+    async fn inform(&mut self, source_capabilities: &SourceCapabilities, _info: Info) {
         // Print capabilities when we receive them
         print_capabilities(source_capabilities);
     }
@@ -446,8 +460,9 @@ pub async fn ucpd_task(mut ucpd_resources: UcpdResources) {
             cc_sel,
         );
 
-        let driver = UcpdSinkDriver::new(pd_phy);
-        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(driver, Device::default());
+        let mut driver = UcpdSinkDriver::new(pd_phy);
+        let mut device = Device::default();
+        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(&mut driver, &mut device);
         info!("Run sink");
 
         match select(sink.run(), wait_detached(&mut cc_phy)).await {

--- a/examples/embassy-stm32-g431cb/src/power.rs
+++ b/examples/embassy-stm32-g431cb/src/power.rs
@@ -255,9 +255,9 @@ pub async fn ucpd_task(mut ucpd_resources: UcpdResources) {
             cc_sel,
         );
 
-        let mut driver = UcpdSinkDriver::new(pd_phy);
-        let mut dpm = Device::default();
-        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(&mut driver, &mut dpm);
+        let driver = UcpdSinkDriver::new(pd_phy);
+        let dpm = Device::default();
+        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(driver, dpm);
         info!("Run sink");
 
         match select(sink.run(), wait_detached(&mut cc_phy)).await {

--- a/examples/embassy-stm32-g431cb/src/power.rs
+++ b/examples/embassy-stm32-g431cb/src/power.rs
@@ -10,7 +10,7 @@ use panic_probe as _;
 use uom::si::electric_potential;
 use usbpd::protocol_layer::message::data::request::{self, CurrentRequest, VoltageRequest};
 use usbpd::protocol_layer::message::data::source_capabilities::SourceCapabilities;
-use usbpd::sink::device_policy_manager::{DevicePolicyManager, Event};
+use usbpd::sink::device_policy_manager::{DevicePolicyManager, DrpDevicePolicyManager, EprDevicePolicyManager, Event, SinkDpm};
 use usbpd::sink::policy_engine::Sink;
 use usbpd::timers::Timer as SinkTimer;
 use usbpd::units::ElectricPotential;
@@ -146,6 +146,13 @@ impl Default for Device {
     }
 }
 
+impl SinkDpm for Device {}
+
+// This device does not have EPR or DRP capabilities, so
+// the trait implementations for both remain empty (default)
+impl DrpDevicePolicyManager for Device {}
+impl EprDevicePolicyManager for Device {}
+
 impl DevicePolicyManager for Device {
     async fn request(&mut self, source_capabilities: &SourceCapabilities) -> request::PowerSource {
         info!("Found capabilities: {}", source_capabilities);
@@ -248,8 +255,9 @@ pub async fn ucpd_task(mut ucpd_resources: UcpdResources) {
             cc_sel,
         );
 
-        let driver = UcpdSinkDriver::new(pd_phy);
-        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(driver, Device::default());
+        let mut driver = UcpdSinkDriver::new(pd_phy);
+        let mut dpm = Device::default();
+        let mut sink: Sink<UcpdSinkDriver<'_>, EmbassySinkTimer, _> = Sink::new(&mut driver, &mut dpm);
         info!("Run sink");
 
         match select(sink.run(), wait_detached(&mut cc_phy)).await {

--- a/examples/embassy-stm32-g431cb/src/power.rs
+++ b/examples/embassy-stm32-g431cb/src/power.rs
@@ -10,7 +10,9 @@ use panic_probe as _;
 use uom::si::electric_potential;
 use usbpd::protocol_layer::message::data::request::{self, CurrentRequest, VoltageRequest};
 use usbpd::protocol_layer::message::data::source_capabilities::SourceCapabilities;
-use usbpd::sink::device_policy_manager::{DevicePolicyManager, DrpDevicePolicyManager, EprDevicePolicyManager, Event, SinkDpm};
+use usbpd::sink::device_policy_manager::{
+    DevicePolicyManager, DrpDevicePolicyManager, EprDevicePolicyManager, Event, SinkDpm,
+};
 use usbpd::sink::policy_engine::Sink;
 use usbpd::timers::Timer as SinkTimer;
 use usbpd::units::ElectricPotential;

--- a/usbpd/src/dual_role.rs
+++ b/usbpd/src/dual_role.rs
@@ -1,0 +1,104 @@
+//! Implementation of a dual role device
+
+use core::marker::PhantomData;
+
+use usbpd_traits::Driver;
+
+use crate::PowerRole;
+use crate::sink::device_policy_manager::SinkDpm;
+use crate::sink::policy_engine::{Error as SinkError, Sink};
+use crate::source::device_policy_manager::SourceDpm;
+use crate::source::policy_engine::{Error as SourceError, Source};
+use crate::timers::Timer;
+
+/// Errors that can occur in the either the sink or source policy engine state machine.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Error while operating as a Sink
+    Sink(SinkError),
+    /// Error while operating as a Source
+    Source(SourceError),
+}
+
+/// Dual Role Port that will automatically undergo role swaps,
+/// using the defined functions in the two `DualRoleDevicePolicyManagers`
+pub struct DualRolePort<DRIVER, TIMER, DPM>
+where
+    DRIVER: Driver,
+    TIMER: Timer,
+    DPM: SourceDpm + SinkDpm,
+{
+    device_policy_manager: DPM,
+    driver: DRIVER,
+    timer: PhantomData<TIMER>,
+}
+
+impl<DRIVER, TIMER, DPM> DualRolePort<DRIVER, TIMER, DPM>
+where
+    DRIVER: Driver,
+    TIMER: Timer,
+    DPM: SourceDpm + SinkDpm,
+{
+    /// Create a new dual role policy engine with a given `driver`.
+    pub fn new(driver: DRIVER, device_policy_manager: DPM) -> Self {
+        Self {
+            device_policy_manager,
+            driver,
+            timer: PhantomData,
+        }
+    }
+
+    /// Run the sink's state machine continuously.
+    ///
+    /// The loop is only broken for unrecoverable errors, for example if the port partner is unresponsive.
+    pub async fn run(&mut self, initial_role: PowerRole) -> Result<(), Error> {
+        let mut role = initial_role;
+        let mut role_swapped = false;
+
+        loop {
+            match role {
+                PowerRole::Source => {
+                    let mut source = Source::<DRIVER, TIMER, DPM>::new_dual_role(
+                        &mut self.driver,
+                        &mut self.device_policy_manager,
+                        role_swapped,
+                    );
+
+                    match source.run().await {
+                        Err(SourceError::SwapToSink) => {
+                            role = PowerRole::Sink;
+                            role_swapped = true;
+                            continue;
+                        }
+                        Err(err) => return Err(Error::Source(err)),
+                        Ok(()) => return Ok(()),
+                    }
+                }
+                PowerRole::Sink => {
+                    let mut sink =
+                        Sink::<DRIVER, TIMER, DPM>::new_dual_role(&mut self.driver, &mut self.device_policy_manager);
+
+                    match sink.run().await {
+                        Err(SinkError::SwapToSource) => {
+                            role = PowerRole::Source;
+                            role_swapped = true;
+                            continue;
+                        }
+                        Err(err) => return Err(Error::Sink(err)),
+                        Ok(()) => return Ok(()),
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    #[tokio::test]
+    async fn test_dual_role() {
+        // TODO: Add tests
+    }
+}

--- a/usbpd/src/dual_role.rs
+++ b/usbpd/src/dual_role.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 
 use usbpd_traits::Driver;
 
-use crate::PowerRole;
+use crate::{PowerRole, RunResult};
 use crate::sink::device_policy_manager::SinkDpm;
 use crate::sink::policy_engine::{Error as SinkError, Sink};
 use crate::source::device_policy_manager::SourceDpm;
@@ -66,13 +66,13 @@ where
                     );
 
                     match source.run().await {
-                        Err(SourceError::SwapToSink) => {
+                        Ok(RunResult::SwapToSink) => {
                             role = PowerRole::Sink;
                             role_swapped = true;
                             continue;
                         }
                         Err(err) => return Err(Error::Source(err)),
-                        Ok(()) => return Ok(()),
+                        Ok(_) => return Ok(()),
                     }
                 }
                 PowerRole::Sink => {
@@ -80,13 +80,13 @@ where
                         Sink::<DRIVER, TIMER, DPM>::new_dual_role(&mut self.driver, &mut self.device_policy_manager);
 
                     match sink.run().await {
-                        Err(SinkError::SwapToSource) => {
+                        Ok(RunResult::SwapToSource) => {
                             role = PowerRole::Source;
                             role_swapped = true;
                             continue;
                         }
                         Err(err) => return Err(Error::Sink(err)),
-                        Ok(()) => return Ok(()),
+                        Ok(_) => return Ok(()),
                     }
                 }
             }

--- a/usbpd/src/dual_role.rs
+++ b/usbpd/src/dual_role.rs
@@ -4,12 +4,12 @@ use core::marker::PhantomData;
 
 use usbpd_traits::Driver;
 
-use crate::{PowerRole, RunResult};
 use crate::sink::device_policy_manager::SinkDpm;
 use crate::sink::policy_engine::{Error as SinkError, Sink};
 use crate::source::device_policy_manager::SourceDpm;
 use crate::source::policy_engine::{Error as SourceError, Source};
 use crate::timers::Timer;
+use crate::{PowerRole, RunResult};
 
 /// Errors that can occur in the either the sink or source policy engine state machine.
 #[derive(Debug)]
@@ -52,44 +52,56 @@ where
     /// Run the sink's state machine continuously.
     ///
     /// The loop is only broken for unrecoverable errors, for example if the port partner is unresponsive.
-    pub async fn run(&mut self, initial_role: PowerRole) -> Result<(), Error> {
+    ///
+    /// NOTE: This function consumes the Dual Role Port Driver. A new driver must be constructed after an error is returned
+    pub async fn run(mut self, initial_role: PowerRole) -> Result<(), Error> {
         let mut role = initial_role;
         let mut role_swapped = false;
 
         loop {
-            match role {
+            (self.driver, self.device_policy_manager) = match role {
                 PowerRole::Source => {
-                    let mut source = Source::<DRIVER, TIMER, DPM>::new_dual_role(
-                        &mut self.driver,
-                        &mut self.device_policy_manager,
-                        role_swapped,
-                    );
-
-                    match source.run().await {
-                        Ok(RunResult::SwapToSink) => {
-                            role = PowerRole::Sink;
-                            role_swapped = true;
-                            continue;
-                        }
-                        Err(err) => return Err(Error::Source(err)),
-                        Ok(_) => return Ok(()),
-                    }
+                    let (driver, dpm) =
+                        Self::run_source_until_swap(self.driver, self.device_policy_manager, role_swapped).await?;
+                    role = PowerRole::Sink;
+                    role_swapped = true;
+                    (driver, dpm)
                 }
                 PowerRole::Sink => {
-                    let mut sink =
-                        Sink::<DRIVER, TIMER, DPM>::new_dual_role(&mut self.driver, &mut self.device_policy_manager);
-
-                    match sink.run().await {
-                        Ok(RunResult::SwapToSource) => {
-                            role = PowerRole::Source;
-                            role_swapped = true;
-                            continue;
-                        }
-                        Err(err) => return Err(Error::Sink(err)),
-                        Ok(_) => return Ok(()),
-                    }
+                    let (driver, dpm) = Self::run_sink_until_swap(self.driver, self.device_policy_manager).await?;
+                    role = PowerRole::Source;
+                    role_swapped = true;
+                    (driver, dpm)
                 }
-            }
+            };
+        }
+    }
+
+    /// An `Ok(...)` result means that a power role swap to Source has been executed,
+    /// and to start running the port as a Source
+    async fn run_sink_until_swap(driver: DRIVER, device_policy_manager: DPM) -> Result<(DRIVER, DPM), Error> {
+        let mut sink = Sink::<DRIVER, TIMER, DPM>::new_dual_role(driver, device_policy_manager);
+
+        match sink.run().await {
+            Ok(RunResult::SwapToSource) => Ok(sink.deconstruct()),
+            Err(err) => Err(Error::Sink(err)),
+            Ok(_) => unreachable!(),
+        }
+    }
+
+    /// An `Ok(...)` result means that a power role swap to Sink has been executed,
+    /// and to start running the port as a Sink
+    async fn run_source_until_swap(
+        driver: DRIVER,
+        device_policy_manager: DPM,
+        role_swapped: bool,
+    ) -> Result<(DRIVER, DPM), Error> {
+        let mut source = Source::<DRIVER, TIMER, DPM>::new_dual_role(driver, device_policy_manager, role_swapped);
+
+        match source.run().await {
+            Ok(RunResult::SwapToSink) => Ok(source.deconstruct()),
+            Err(err) => Err(Error::Source(err)),
+            Ok(_) => unreachable!(),
         }
     }
 }

--- a/usbpd/src/dual_role.rs
+++ b/usbpd/src/dual_role.rs
@@ -105,29 +105,3 @@ where
         }
     }
 }
-
-#[cfg(test)]
-mod test {
-    use dummy::{DummyDriver, DummyDualRoleDevice, DummyTimer, MAX_DATA_MESSAGE_SIZE};
-
-    use crate::dual_role::DualRolePort;
-    use crate::dummy;
-    use crate::sink::device_policy_manager::SinkDpm;
-    use crate::source::device_policy_manager::SourceDpm;
-
-    #[tokio::test]
-    async fn test_dual_role() {
-        let mut driver = DummyDriver::<MAX_DATA_MESSAGE_SIZE>::new();
-        let mut device = DummyDualRoleDevice {};
-        let mut policy_engine: DualRolePort<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DummyDualRoleDevice> =
-            DualRolePort::new(driver, device);
-
-        // Traverse Sink -> Source and Source -> Sink swaps
-
-        // FIXME: Have dual role specific tests rather than the swap
-        // tests existing on the `sink` and `source` separately.
-
-        // This would involve changing `DualRolePort` to have a `run_step()` function
-        // alongside a `run()` function.
-    }
-}

--- a/usbpd/src/dual_role.rs
+++ b/usbpd/src/dual_role.rs
@@ -96,9 +96,26 @@ where
 
 #[cfg(test)]
 mod test {
+    use dummy::{DummyDriver, DummyDualRoleDevice, DummyTimer, MAX_DATA_MESSAGE_SIZE};
+
+    use crate::dual_role::DualRolePort;
+    use crate::dummy;
+    use crate::sink::device_policy_manager::SinkDpm;
+    use crate::source::device_policy_manager::SourceDpm;
 
     #[tokio::test]
     async fn test_dual_role() {
-        // TODO: Add tests
+        let mut driver = DummyDriver::<MAX_DATA_MESSAGE_SIZE>::new();
+        let mut device = DummyDualRoleDevice {};
+        let mut policy_engine: DualRolePort<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DummyDualRoleDevice> =
+            DualRolePort::new(driver, device);
+
+        // Traverse Sink -> Source and Source -> Sink swaps
+
+        // FIXME: Have dual role specific tests rather than the swap
+        // tests existing on the `sink` and `source` separately.
+
+        // This would involve changing `DualRolePort` to have a `run_step()` function
+        // alongside a `run()` function.
     }
 }

--- a/usbpd/src/dummy.rs
+++ b/usbpd/src/dummy.rs
@@ -5,15 +5,18 @@ use std::vec::Vec;
 use uom::si::power::watt;
 use usbpd_traits::Driver;
 
-use crate::protocol_layer::message::data::request::{self, EprRequestDataObject};
+use crate::SwapType;
+use crate::protocol_layer::message::data::request::{self, EprRequestDataObject, PowerSource};
 use crate::protocol_layer::message::data::source_capabilities::{
     Augmented, FixedSupply, PowerDataObject, SourceCapabilities, SprProgrammablePowerSupply,
 };
-use crate::sink::device_policy_manager::DevicePolicyManager as SinkDevicePolicyManager;
+use crate::sink::device_policy_manager::{
+    DevicePolicyManager as SinkDPM, DrpDevicePolicyManager as SinkDrpDPM, EprDevicePolicyManager as SinkEprDPM,
+    Event as SinkEvent, SinkDpm,
+};
 use crate::source::device_policy_manager::{
-    CapabilityResponse as SourceCapabilityResponse, DevicePolicyManager as SourceDevicePolicyManager,
-    DualRoleDevicePolicyManager as SourceDrpDevicePolicyManager,
-    EprDevicePolicyManager as SourceEprDevicePolicyManager, SourceDpm, SwapType,
+    CapabilityResponse as SourceCapabilityResponse, DevicePolicyManager as SourceDPM,
+    DrpDevicePolicyManager as SourceDrpDPM, EprDevicePolicyManager as SourceEprDPM, SourceDpm,
 };
 use crate::timers::Timer;
 use crate::units::Power;
@@ -42,10 +45,17 @@ pub const DUMMY_EPR_SOURCE_CAPS_CHUNK_1: [u8; 18] = [
 /// Per USB PD spec, this is 2 bytes header + 7 data objects * 4 bytes = 30 bytes.
 pub const MAX_DATA_MESSAGE_SIZE: usize = 30;
 
+/// Maximum object position an SPR PDO should be in.
+/// Used to evaluate capability requests naively for source dummies.
+const MAX_SPR_OBJ_POS: u8 = 8;
+
 /// A dummy sink device that implements the sink device policy manager.
 pub struct DummySinkDevice {}
 
-impl SinkDevicePolicyManager for DummySinkDevice {}
+impl SinkDPM for DummySinkDevice {}
+impl SinkDrpDPM for DummySinkDevice {}
+impl SinkEprDPM for DummySinkDevice {}
+impl SinkDpm for DummySinkDevice {}
 
 /// A dummy EPR-capable sink device that requests EPR power.
 ///
@@ -64,29 +74,24 @@ impl DummySinkEprDevice {
     }
 }
 
-impl SinkDevicePolicyManager for DummySinkEprDevice {
-    async fn get_event(
-        &mut self,
-        source_capabilities: &SourceCapabilities,
-    ) -> crate::sink::device_policy_manager::Event {
-        use crate::sink::device_policy_manager::Event;
-
+impl SinkDPM for DummySinkEprDevice {
+    async fn get_event(&mut self, source_capabilities: &SourceCapabilities) -> SinkEvent {
         // After initial SPR negotiation, enter EPR mode if source is EPR capable
         if !self.requested_epr_caps {
             // Check if source advertises EPR capability in first PDO
             if let Some(PowerDataObject::FixedSupply(fixed)) = source_capabilities.pdos().first() {
                 if fixed.epr_mode_capable() {
                     self.requested_epr_caps = true;
-                    return Event::EnterEprMode(Power::new::<watt>(140)); // Dummy 140W PDP
+                    return SinkEvent::EnterEprMode(Power::new::<watt>(140)); // Dummy 140W PDP
                 }
             }
         }
 
-        Event::None
+        SinkEvent::None
     }
 
-    async fn request(&mut self, source_capabilities: &SourceCapabilities) -> request::PowerSource {
-        use crate::protocol_layer::message::data::request::{CurrentRequest, PowerSource, VoltageRequest};
+    async fn request(&mut self, source_capabilities: &SourceCapabilities) -> PowerSource {
+        use crate::protocol_layer::message::data::request::{CurrentRequest, VoltageRequest};
         use crate::protocol_layer::message::data::source_capabilities::PowerDataObject;
 
         // Use the spec-compliant epr_pdos() method to get EPR PDOs at positions 8+
@@ -122,9 +127,14 @@ impl SinkDevicePolicyManager for DummySinkEprDevice {
     }
 }
 
+impl SinkDrpDPM for DummySinkEprDevice {}
+impl SinkEprDPM for DummySinkEprDevice {}
+impl SinkDpm for DummySinkEprDevice {}
+
+/// A dummy capable of sourcing non-EPR power
 pub struct DummySourceDevice;
 
-impl SourceDevicePolicyManager for DummySourceDevice {
+impl SourceDPM for DummySourceDevice {
     async fn evaluate_request(&mut self, request: &request::PowerSource) -> SourceCapabilityResponse {
         if request.object_position() < 8 {
             SourceCapabilityResponse::Accept
@@ -138,15 +148,16 @@ impl SourceDevicePolicyManager for DummySourceDevice {
     }
 }
 
-impl SourceDrpDevicePolicyManager for DummySourceDevice {}
-impl SourceEprDevicePolicyManager for DummySourceDevice {}
+impl SourceDrpDPM for DummySourceDevice {}
+impl SourceEprDPM for DummySourceDevice {}
 impl SourceDpm for DummySourceDevice {}
 
+/// A dual role device that will reject all swap requests
 pub struct DummyDualRoleNoSwapsDevice;
 
-impl SourceDevicePolicyManager for DummyDualRoleNoSwapsDevice {
-    async fn evaluate_request(&mut self, request: &request::PowerSource) -> SourceCapabilityResponse {
-        if request.object_position() < 8 {
+impl SourceDPM for DummyDualRoleNoSwapsDevice {
+    async fn evaluate_request(&mut self, request: &PowerSource) -> SourceCapabilityResponse {
+        if request.object_position() < MAX_SPR_OBJ_POS {
             SourceCapabilityResponse::Accept
         } else {
             SourceCapabilityResponse::Reject
@@ -157,31 +168,19 @@ impl SourceDevicePolicyManager for DummyDualRoleNoSwapsDevice {
         SourceCapabilities(heapless::Vec::from_slice(get_dummy_source_capabilities().as_slice()).unwrap())
     }
 }
+impl SourceEprDPM for DummyDualRoleNoSwapsDevice {}
+impl SourceDrpDPM for DummyDualRoleNoSwapsDevice {}
+impl SourceDpm for DummyDualRoleNoSwapsDevice {}    // Defaults to rejecting swaps
 
-impl SourceDrpDevicePolicyManager for DummyDualRoleNoSwapsDevice {
-    async fn evaluate_swap_request(&mut self, swap_request: SwapType) -> bool {
-        match swap_request {
-            SwapType::Data => false,
-            SwapType::Power => false,
-        }
-    }
-
-    async fn fr_swap_signaled(&mut self) -> bool {
-        false
-    }
-}
-
-impl SourceEprDevicePolicyManager for DummyDualRoleNoSwapsDevice {}
-
-impl SourceDpm for DummyDualRoleNoSwapsDevice {}
-
-impl SinkDevicePolicyManager for DummyDualRoleNoSwapsDevice {}
+impl SinkDPM for DummyDualRoleNoSwapsDevice {}
+impl SinkDrpDPM for DummyDualRoleNoSwapsDevice {}
+impl SinkEprDPM for DummyDualRoleNoSwapsDevice {}
+impl SinkDpm for DummyDualRoleNoSwapsDevice {}      // Defaults to rejecting swaps
 
 pub struct DummyDualRoleDevice;
 
-impl SourceDevicePolicyManager for DummyDualRoleDevice {
-    async fn evaluate_request(&mut self, request: &request::PowerSource) -> SourceCapabilityResponse {
-        const MAX_SPR_OBJ_POS: u8 = 8;
+impl SourceDPM for DummyDualRoleDevice {
+    async fn evaluate_request(&mut self, request: &PowerSource) -> SourceCapabilityResponse {
         if request.object_position() < MAX_SPR_OBJ_POS {
             SourceCapabilityResponse::Accept
         } else {
@@ -194,7 +193,7 @@ impl SourceDevicePolicyManager for DummyDualRoleDevice {
     }
 }
 
-impl SourceDrpDevicePolicyManager for DummyDualRoleDevice {
+impl SourceDrpDPM for DummyDualRoleDevice {
     async fn evaluate_swap_request(&mut self, swap_request: SwapType) -> bool {
         match swap_request {
             SwapType::Data => true,
@@ -207,11 +206,13 @@ impl SourceDrpDevicePolicyManager for DummyDualRoleDevice {
     }
 }
 
-impl SourceEprDevicePolicyManager for DummyDualRoleDevice {}
-
+impl SourceEprDPM for DummyDualRoleDevice {}
 impl SourceDpm for DummyDualRoleDevice {}
 
-impl SinkDevicePolicyManager for DummyDualRoleDevice {}
+impl SinkDPM for DummyDualRoleDevice {}
+impl SinkDrpDPM for DummyDualRoleDevice {}
+impl SinkEprDPM for DummyDualRoleDevice {}
+impl SinkDpm for DummyDualRoleDevice {}
 
 /// A dummy timer for testing.
 pub struct DummyTimer {}
@@ -345,8 +346,8 @@ pub const DUMMY_CAPABILITIES: [u8; 30] = [
     0xC9, // +
 ];
 
-pub fn get_source_capability_request() -> request::PowerSource {
-    request::PowerSource::new_fixed(
+pub fn get_source_capability_request() -> PowerSource {
+    PowerSource::new_fixed(
         request::CurrentRequest::Highest,
         request::VoltageRequest::Safe5V,
         &SourceCapabilities(heapless::Vec::from_slice(&get_dummy_source_capabilities()).unwrap()),

--- a/usbpd/src/dummy.rs
+++ b/usbpd/src/dummy.rs
@@ -170,12 +170,12 @@ impl SourceDPM for DummyDualRoleNoSwapsDevice {
 }
 impl SourceEprDPM for DummyDualRoleNoSwapsDevice {}
 impl SourceDrpDPM for DummyDualRoleNoSwapsDevice {}
-impl SourceDpm for DummyDualRoleNoSwapsDevice {}    // Defaults to rejecting swaps
+impl SourceDpm for DummyDualRoleNoSwapsDevice {} // Defaults to rejecting swaps
 
 impl SinkDPM for DummyDualRoleNoSwapsDevice {}
 impl SinkDrpDPM for DummyDualRoleNoSwapsDevice {}
 impl SinkEprDPM for DummyDualRoleNoSwapsDevice {}
-impl SinkDpm for DummyDualRoleNoSwapsDevice {}      // Defaults to rejecting swaps
+impl SinkDpm for DummyDualRoleNoSwapsDevice {} // Defaults to rejecting swaps
 
 pub struct DummyDualRoleDevice;
 

--- a/usbpd/src/dummy.rs
+++ b/usbpd/src/dummy.rs
@@ -152,31 +152,6 @@ impl SourceDrpDPM for DummySourceDevice {}
 impl SourceEprDPM for DummySourceDevice {}
 impl SourceDpm for DummySourceDevice {}
 
-/// A dual role device that will reject all swap requests
-pub struct DummyDualRoleNoSwapsDevice;
-
-impl SourceDPM for DummyDualRoleNoSwapsDevice {
-    async fn evaluate_request(&mut self, request: &PowerSource) -> SourceCapabilityResponse {
-        if request.object_position() < MAX_SPR_OBJ_POS {
-            SourceCapabilityResponse::Accept
-        } else {
-            SourceCapabilityResponse::Reject
-        }
-    }
-
-    fn source_capabilities(&mut self) -> SourceCapabilities {
-        SourceCapabilities(heapless::Vec::from_slice(get_dummy_source_capabilities().as_slice()).unwrap())
-    }
-}
-impl SourceEprDPM for DummyDualRoleNoSwapsDevice {}
-impl SourceDrpDPM for DummyDualRoleNoSwapsDevice {}
-impl SourceDpm for DummyDualRoleNoSwapsDevice {} // Defaults to rejecting swaps
-
-impl SinkDPM for DummyDualRoleNoSwapsDevice {}
-impl SinkDrpDPM for DummyDualRoleNoSwapsDevice {}
-impl SinkEprDPM for DummyDualRoleNoSwapsDevice {}
-impl SinkDpm for DummyDualRoleNoSwapsDevice {} // Defaults to rejecting swaps
-
 pub struct DummyDualRoleDevice;
 
 impl SourceDPM for DummyDualRoleDevice {

--- a/usbpd/src/lib.rs
+++ b/usbpd/src/lib.rs
@@ -24,6 +24,7 @@ extern crate uom;
 pub(crate) mod fmt;
 
 pub(crate) mod counters;
+pub mod dual_role;
 pub mod protocol_layer;
 pub mod sink;
 pub mod source;
@@ -152,6 +153,29 @@ impl From<DataRole> for bool {
             DataRole::Dfp => true,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+enum Contract {
+    #[default]
+    Safe5V,
+    Implicit, // Only present after fast role swap. Limited to max. type C current.
+    TransitionToExplicit,
+    Explicit(crate::protocol_layer::message::data::request::PowerSource),
+
+    // FIXME: EPR support may use this enum
+    #[allow(unused)]
+    _Invalid,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+/// For defining Device Policy Managers' swap behavior
+pub enum SwapType {
+    /// **DRP** Data Role Swap (UFP <---> DFP)
+    Data,
+    /// **DRP** Power Role Swap (Source <---> Sink)
+    Power,
 }
 
 #[cfg(test)]

--- a/usbpd/src/lib.rs
+++ b/usbpd/src/lib.rs
@@ -178,6 +178,24 @@ pub enum SwapType {
     Power,
 }
 
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+/// Inner policy engine results to determine whether to exit the policy engine or not
+enum PolicyEngineResult {
+    Continue,
+    Exit(RunResult)
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+/// Action to execute upon successfully exiting a port's policy engine handler
+pub enum RunResult {
+    /// **DRP** Sink -> Source
+    SwapToSource,
+    /// **DRP** Source -> Sink
+    SwapToSink,
+}
+
 #[cfg(test)]
 mod tests {
     use uom::si::electric_current::milliampere;

--- a/usbpd/src/lib.rs
+++ b/usbpd/src/lib.rs
@@ -183,7 +183,7 @@ pub enum SwapType {
 /// Inner policy engine results to determine whether to exit the policy engine or not
 enum PolicyEngineResult {
     Continue,
-    Exit(RunResult)
+    Exit(RunResult),
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/usbpd/src/protocol_layer/mod.rs
+++ b/usbpd/src/protocol_layer/mod.rs
@@ -123,8 +123,8 @@ impl Default for Counters {
 
 /// The USB PD protocol layer.
 #[derive(Debug)]
-pub(crate) struct ProtocolLayer<DRIVER: Driver, TIMER: Timer> {
-    driver: DRIVER,
+pub(crate) struct ProtocolLayer<'a, DRIVER: Driver, TIMER: Timer> {
+    driver: &'a mut DRIVER,
     counters: Counters,
     default_header: Header,
     extended_rx_buffer: Vec<u8, MAX_MESSAGE_SIZE>,
@@ -132,9 +132,9 @@ pub(crate) struct ProtocolLayer<DRIVER: Driver, TIMER: Timer> {
     _timer: PhantomData<TIMER>,
 }
 
-impl<DRIVER: Driver, TIMER: Timer> ProtocolLayer<DRIVER, TIMER> {
+impl<'a, DRIVER: Driver, TIMER: Timer> ProtocolLayer<'a, DRIVER, TIMER> {
     /// Create a new protocol layer from a driver and default header.
-    pub fn new(driver: DRIVER, default_header: Header) -> Self {
+    pub fn new(driver: &'a mut DRIVER, default_header: Header) -> Self {
         Self {
             driver,
             counters: Default::default(),
@@ -843,24 +843,24 @@ impl<DRIVER: Driver, TIMER: Timer> ProtocolLayer<DRIVER, TIMER> {
 #[repr(transparent)]
 #[derive(Debug)]
 /// The USB PD Protocol Layer for a `Sink`
-pub(crate) struct SinkProtocolLayer<DRIVER: Driver, TIMER: Timer>(ProtocolLayer<DRIVER, TIMER>);
+pub(crate) struct SinkProtocolLayer<'a, DRIVER: Driver, TIMER: Timer>(ProtocolLayer<'a, DRIVER, TIMER>);
 
-impl<DRIVER: Driver, TIMER: Timer> core::ops::Deref for SinkProtocolLayer<DRIVER, TIMER> {
-    type Target = ProtocolLayer<DRIVER, TIMER>;
+impl<'a, DRIVER: Driver, TIMER: Timer> core::ops::Deref for SinkProtocolLayer<'a, DRIVER, TIMER> {
+    type Target = ProtocolLayer<'a, DRIVER, TIMER>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<DRIVER: Driver, TIMER: Timer> core::ops::DerefMut for SinkProtocolLayer<DRIVER, TIMER> {
+impl<'a, DRIVER: Driver, TIMER: Timer> core::ops::DerefMut for SinkProtocolLayer<'a, DRIVER, TIMER> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<DRIVER: Driver, TIMER: Timer> SinkProtocolLayer<DRIVER, TIMER> {
+impl<'a, DRIVER: Driver, TIMER: Timer> SinkProtocolLayer<'a, DRIVER, TIMER> {
     /// Create a new protocol layer from a driver and default header.
-    pub fn new(driver: DRIVER, default_header: Header) -> Self {
+    pub fn new(driver: &'a mut DRIVER, default_header: Header) -> Self {
         Self(ProtocolLayer::new(driver, default_header))
     }
 
@@ -896,24 +896,24 @@ impl<DRIVER: Driver, TIMER: Timer> SinkProtocolLayer<DRIVER, TIMER> {
 #[repr(transparent)]
 #[derive(Debug)]
 /// The USB PD Protocol Layer for a `Source`
-pub(crate) struct SourceProtocolLayer<DRIVER: Driver, TIMER: Timer>(ProtocolLayer<DRIVER, TIMER>);
+pub(crate) struct SourceProtocolLayer<'a, DRIVER: Driver, TIMER: Timer>(ProtocolLayer<'a, DRIVER, TIMER>);
 
-impl<DRIVER: Driver, TIMER: Timer> core::ops::Deref for SourceProtocolLayer<DRIVER, TIMER> {
-    type Target = ProtocolLayer<DRIVER, TIMER>;
+impl<'a, DRIVER: Driver, TIMER: Timer> core::ops::Deref for SourceProtocolLayer<'a, DRIVER, TIMER> {
+    type Target = ProtocolLayer<'a, DRIVER, TIMER>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<DRIVER: Driver, TIMER: Timer> core::ops::DerefMut for SourceProtocolLayer<DRIVER, TIMER> {
+impl<'a, DRIVER: Driver, TIMER: Timer> core::ops::DerefMut for SourceProtocolLayer<'a, DRIVER, TIMER> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<DRIVER: Driver, TIMER: Timer> SourceProtocolLayer<DRIVER, TIMER> {
+impl<'a, DRIVER: Driver, TIMER: Timer> SourceProtocolLayer<'a, DRIVER, TIMER> {
     /// Create a new protocol layer from a driver and default header.
-    pub fn new(driver: DRIVER, default_header: Header) -> Self {
+    pub fn new(driver: &'a mut DRIVER, default_header: Header) -> Self {
         Self(ProtocolLayer::new(driver, default_header))
     }
 
@@ -956,9 +956,11 @@ mod tests {
     };
     use crate::protocol_layer::message::Payload;
 
-    fn get_protocol_layer() -> ProtocolLayer<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer> {
+    fn get_protocol_layer<'a>(
+        driver: &'a mut DummyDriver<MAX_DATA_MESSAGE_SIZE>,
+    ) -> ProtocolLayer<'a, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer> {
         ProtocolLayer::new(
-            DummyDriver::new(),
+            driver,
             Header::new_template(
                 crate::DataRole::Ufp,
                 crate::PowerRole::Sink,
@@ -969,7 +971,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_it() {
-        let mut protocol_layer = get_protocol_layer();
+        let mut driver = DummyDriver::new();
+        let mut protocol_layer = get_protocol_layer(&mut driver);
 
         protocol_layer.driver.inject_received_data(&DUMMY_CAPABILITIES);
         let message = protocol_layer.receive_message().await.unwrap();

--- a/usbpd/src/protocol_layer/mod.rs
+++ b/usbpd/src/protocol_layer/mod.rs
@@ -123,8 +123,8 @@ impl Default for Counters {
 
 /// The USB PD protocol layer.
 #[derive(Debug)]
-pub(crate) struct ProtocolLayer<'a, DRIVER: Driver, TIMER: Timer> {
-    driver: &'a mut DRIVER,
+pub(crate) struct ProtocolLayer<DRIVER: Driver, TIMER: Timer> {
+    driver: DRIVER,
     counters: Counters,
     default_header: Header,
     extended_rx_buffer: Vec<u8, MAX_MESSAGE_SIZE>,
@@ -132,9 +132,9 @@ pub(crate) struct ProtocolLayer<'a, DRIVER: Driver, TIMER: Timer> {
     _timer: PhantomData<TIMER>,
 }
 
-impl<'a, DRIVER: Driver, TIMER: Timer> ProtocolLayer<'a, DRIVER, TIMER> {
+impl<DRIVER: Driver, TIMER: Timer> ProtocolLayer<DRIVER, TIMER> {
     /// Create a new protocol layer from a driver and default header.
-    pub fn new(driver: &'a mut DRIVER, default_header: Header) -> Self {
+    pub fn new(driver: DRIVER, default_header: Header) -> Self {
         Self {
             driver,
             counters: Default::default(),
@@ -143,6 +143,10 @@ impl<'a, DRIVER: Driver, TIMER: Timer> ProtocolLayer<'a, DRIVER, TIMER> {
             extended_rx_expected: None,
             _timer: PhantomData,
         }
+    }
+
+    pub fn deconstruct(self) -> DRIVER {
+        self.driver
     }
 
     /// Reset the protocol layer.
@@ -836,25 +840,29 @@ impl<'a, DRIVER: Driver, TIMER: Timer> ProtocolLayer<'a, DRIVER, TIMER> {
 #[repr(transparent)]
 #[derive(Debug)]
 /// The USB PD Protocol Layer for a `Sink`
-pub(crate) struct SinkProtocolLayer<'a, DRIVER: Driver, TIMER: Timer>(ProtocolLayer<'a, DRIVER, TIMER>);
+pub(crate) struct SinkProtocolLayer<DRIVER: Driver, TIMER: Timer>(ProtocolLayer<DRIVER, TIMER>);
 
-impl<'a, DRIVER: Driver, TIMER: Timer> core::ops::Deref for SinkProtocolLayer<'a, DRIVER, TIMER> {
-    type Target = ProtocolLayer<'a, DRIVER, TIMER>;
+impl<DRIVER: Driver, TIMER: Timer> core::ops::Deref for SinkProtocolLayer<DRIVER, TIMER> {
+    type Target = ProtocolLayer<DRIVER, TIMER>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a, DRIVER: Driver, TIMER: Timer> core::ops::DerefMut for SinkProtocolLayer<'a, DRIVER, TIMER> {
+impl<DRIVER: Driver, TIMER: Timer> core::ops::DerefMut for SinkProtocolLayer<DRIVER, TIMER> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<'a, DRIVER: Driver, TIMER: Timer> SinkProtocolLayer<'a, DRIVER, TIMER> {
+impl<DRIVER: Driver, TIMER: Timer> SinkProtocolLayer<DRIVER, TIMER> {
     /// Create a new protocol layer from a driver and default header.
-    pub fn new(driver: &'a mut DRIVER, default_header: Header) -> Self {
+    pub fn new(driver: DRIVER, default_header: Header) -> Self {
         Self(ProtocolLayer::new(driver, default_header))
+    }
+
+    pub fn deconstruct(self) -> DRIVER {
+        self.0.deconstruct()
     }
 
     /// Wait for the source to provide its capabilities.
@@ -889,25 +897,29 @@ impl<'a, DRIVER: Driver, TIMER: Timer> SinkProtocolLayer<'a, DRIVER, TIMER> {
 #[repr(transparent)]
 #[derive(Debug)]
 /// The USB PD Protocol Layer for a `Source`
-pub(crate) struct SourceProtocolLayer<'a, DRIVER: Driver, TIMER: Timer>(ProtocolLayer<'a, DRIVER, TIMER>);
+pub(crate) struct SourceProtocolLayer<DRIVER: Driver, TIMER: Timer>(ProtocolLayer<DRIVER, TIMER>);
 
-impl<'a, DRIVER: Driver, TIMER: Timer> core::ops::Deref for SourceProtocolLayer<'a, DRIVER, TIMER> {
-    type Target = ProtocolLayer<'a, DRIVER, TIMER>;
+impl<DRIVER: Driver, TIMER: Timer> core::ops::Deref for SourceProtocolLayer<DRIVER, TIMER> {
+    type Target = ProtocolLayer<DRIVER, TIMER>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a, DRIVER: Driver, TIMER: Timer> core::ops::DerefMut for SourceProtocolLayer<'a, DRIVER, TIMER> {
+impl<DRIVER: Driver, TIMER: Timer> core::ops::DerefMut for SourceProtocolLayer<DRIVER, TIMER> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<'a, DRIVER: Driver, TIMER: Timer> SourceProtocolLayer<'a, DRIVER, TIMER> {
+impl<DRIVER: Driver, TIMER: Timer> SourceProtocolLayer<DRIVER, TIMER> {
     /// Create a new protocol layer from a driver and default header.
-    pub fn new(driver: &'a mut DRIVER, default_header: Header) -> Self {
+    pub fn new(driver: DRIVER, default_header: Header) -> Self {
         Self(ProtocolLayer::new(driver, default_header))
+    }
+
+    pub fn deconstruct(self) -> DRIVER {
+        self.0.deconstruct()
     }
 
     /// Wait for the sink to request a capability with a Request Message.
@@ -950,8 +962,8 @@ mod tests {
     use crate::protocol_layer::message::Payload;
 
     fn get_protocol_layer<'a>(
-        driver: &'a mut DummyDriver<MAX_DATA_MESSAGE_SIZE>,
-    ) -> ProtocolLayer<'a, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer> {
+        driver: DummyDriver<MAX_DATA_MESSAGE_SIZE>,
+    ) -> ProtocolLayer<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer> {
         ProtocolLayer::new(
             driver,
             Header::new_template(
@@ -964,8 +976,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_it() {
-        let mut driver = DummyDriver::new();
-        let mut protocol_layer = get_protocol_layer(&mut driver);
+        let mut protocol_layer = get_protocol_layer(DummyDriver::new());
 
         protocol_layer.driver.inject_received_data(&DUMMY_CAPABILITIES);
         let message = protocol_layer.receive_message().await.unwrap();

--- a/usbpd/src/protocol_layer/mod.rs
+++ b/usbpd/src/protocol_layer/mod.rs
@@ -161,13 +161,6 @@ impl<'a, DRIVER: Driver, TIMER: Timer> ProtocolLayer<'a, DRIVER, TIMER> {
         &self.default_header
     }
 
-    /// Change the header's data role after a data role swap
-    /// FIXME: Use this after a data role swap
-    #[allow(unused)]
-    pub fn set_header_data_role(&mut self, role: crate::DataRole) {
-        self.default_header.set_port_data_role(role);
-    }
-
     fn get_message_buffer() -> [u8; MAX_MESSAGE_SIZE] {
         [0u8; MAX_MESSAGE_SIZE]
     }

--- a/usbpd/src/sink/device_policy_manager.rs
+++ b/usbpd/src/sink/device_policy_manager.rs
@@ -6,6 +6,7 @@ use core::future::Future;
 
 use crate::protocol_layer::message::data::{epr_mode, request, sink_capabilities, source_capabilities};
 use crate::units::Power;
+use crate::{DataRole, SwapType};
 
 /// Events that the device policy manager can send to the policy engine.
 #[derive(Debug)]
@@ -37,14 +38,41 @@ pub enum Event {
     ExitEprMode,
     /// Request a certain power level.
     RequestPower(request::PowerSource),
+    /// Indicate that a Vconn swap needs to be done
+    RequestVconnSwap,
+    /// **DRP** Request that a data role swap be done
+    RequestDataRoleSwap,
+    /// **DRP** Request that a power role swap be done
+    RequestPowerRoleSwap,
+    /// **DRP** Indicate that a fast power role swap needs to be attempted
+    /// due to the CC line going low
+    FastPowerRoleSwap,
 }
+
+/// Information that the policy engine will publish to the DPM
+#[derive(Debug)]
+pub enum Info {
+    /// Request is not supported by the Source
+    NotSupportedReceived,
+    /// No special information (because `SourceCapabilities` is always sent)
+    None,
+}
+
+// FIXME: Use trait aliasing once stable: https://github.com/rust-lang/rust/issues/41517
+/// Full implementation for the source device policy manager.
+/// The default implementations of the traits will handle the case where a feature is unsupported.
+pub trait SinkDpm: DevicePolicyManager + EprDevicePolicyManager + DrpDevicePolicyManager {}
 
 /// Trait for the device policy manager.
 ///
 /// This entity commands the policy engine and enforces device policy.
 pub trait DevicePolicyManager {
     /// Inform the device about source capabilities, e.g. after a request.
-    fn inform(&mut self, _source_capabilities: &source_capabilities::SourceCapabilities) -> impl Future<Output = ()> {
+    fn inform(
+        &mut self,
+        _source_capabilities: &source_capabilities::SourceCapabilities,
+        _info: Info,
+    ) -> impl Future<Output = ()> {
         async {}
     }
 
@@ -85,22 +113,6 @@ pub trait DevicePolicyManager {
         async {}
     }
 
-    /// Notify the device that EPR mode entry failed.
-    ///
-    /// Per USB PD Spec R3.2 Section 8.3.3.26.2.1, when the source responds with
-    /// EPR_Mode (Enter Failed), the sink transitions to soft reset. This callback
-    /// informs the DPM of the failure reason before the soft reset occurs.
-    ///
-    /// The failure reasons are defined in Table 6.50 and include:
-    /// - Cable not EPR capable
-    /// - Source failed to become VCONN source
-    /// - EPR capable bit not set in RDO
-    /// - Source unable to enter EPR mode (sink may retry later)
-    /// - EPR capable bit not set in PDO
-    fn epr_mode_entry_failed(&mut self, _reason: epr_mode::DataEnterFailed) -> impl Future<Output = ()> {
-        async {}
-    }
-
     /// Get the sink's power capabilities.
     ///
     /// Per USB PD Spec R3.2 Section 6.4.1.6, sinks respond to Get_Sink_Cap messages
@@ -112,6 +124,16 @@ pub trait DevicePolicyManager {
     fn sink_capabilities(&self) -> sink_capabilities::SinkCapabilities {
         // Default: 5V @ 100mA (1A = 100 * 10mA)
         sink_capabilities::SinkCapabilities::new_vsafe5v_only(100)
+    }
+
+    /// Evaluate whether a vconn swap can be done by the device or not.
+    fn evaluate_vconn_swap_request(&mut self) -> impl Future<Output = bool> {
+        async { false }
+    }
+
+    /// Set port to drive VCONN to 5V (true) or not (false)
+    fn drive_vconn(&mut self, _on: bool) -> impl Future<Output = Result<(), ()>> {
+        async { Ok(()) }
     }
 
     /// The policy engine gets and evaluates device policy events when ready.
@@ -129,5 +151,71 @@ pub trait DevicePolicyManager {
         _source_capabilities: &source_capabilities::SourceCapabilities,
     ) -> impl Future<Output = Event> {
         async { core::future::pending().await }
+    }
+}
+
+/// **EPR** Extended Power Range device implementations
+///
+/// Leave blank if the device does not support EPR.
+pub trait EprDevicePolicyManager {
+    /// Notify the device that EPR mode entry failed.
+    ///
+    /// Per USB PD Spec R3.2 Section 8.3.3.26.2.1, when the source responds with
+    /// EPR_Mode (Enter Failed), the sink transitions to soft reset. This callback
+    /// informs the DPM of the failure reason before the soft reset occurs.
+    ///
+    /// The failure reasons are defined in Table 6.50 and include:
+    /// - Cable not EPR capable
+    /// - Source failed to become VCONN source
+    /// - EPR capable bit not set in RDO
+    /// - Source unable to enter EPR mode (sink may retry later)
+    /// - EPR capable bit not set in PDO
+    fn epr_mode_entry_failed(&mut self, _reason: epr_mode::DataEnterFailed) -> impl Future<Output = ()> {
+        async {}
+    }
+}
+
+/// **DRP** Dual Role Sink Port device implementations
+///
+/// Leave blank if the device is not a DRP.
+pub trait DrpDevicePolicyManager {
+    /// **DRP** Evaluate a swap request
+    fn evaluate_swap_request(&mut self, _swap_request: SwapType) -> impl Future<Output = bool> {
+        async { false }
+    }
+
+    /// **DRP** Disable/Enable Fast Role Swap Receiver
+    ///
+    /// A DRP Sink is expected to detect when the CC line indicates a
+    /// `Fast Role Swap`. During regular `Power Role` swaps, this will
+    /// be called to disable the detection to avoid false positives.
+    fn set_fr_swap_detect(_enable: bool) -> impl Future<Output = ()> {
+        async {}
+    }
+
+    /// **DRP** Turn the Sink off.
+    ///
+    /// This will be requested during a Power Role Swap to Source.
+    fn disable(&mut self) -> impl Future<Output = ()> {
+        async {}
+    }
+
+    /// **DRP** Swap the CC pins to the `Source` configuration.
+    ///
+    /// This will be requested during a Power Role Swap to Source.
+    fn cc_source(&mut self) -> impl Future<Output = ()> {
+        async {}
+    }
+
+    /// **DRP** Turn on the Source. Return once `Vbus` is at `vSafe5V`.
+    ///
+    /// This will be requested during a Power Role Swap to Source.
+    fn source_on(&mut self) -> impl Future<Output = ()> {
+        async {}
+    }
+
+    /// **DRP** Swap data role.
+    fn swap_data_role(&mut self, _role: DataRole) -> impl Future<Output = ()> {
+        async {}
     }
 }

--- a/usbpd/src/sink/policy_engine/mod.rs
+++ b/usbpd/src/sink/policy_engine/mod.rs
@@ -5,7 +5,7 @@ use embassy_futures::select::{Either3, select3};
 use uom::si::power::watt;
 use usbpd_traits::Driver;
 
-use super::device_policy_manager::DevicePolicyManager;
+use super::device_policy_manager::{Event, Info, SinkDpm};
 use crate::counters::Counter;
 use crate::protocol_layer::message::data::epr_mode::{self, Action};
 use crate::protocol_layer::message::data::request::PowerSource;
@@ -17,9 +17,8 @@ use crate::protocol_layer::message::header::{
 };
 use crate::protocol_layer::message::{Payload, extended};
 use crate::protocol_layer::{ProtocolError, RxError, SinkProtocolLayer, TxError};
-use crate::sink::device_policy_manager::Event;
 use crate::timers::{Timer, TimerType};
-use crate::{DataRole, PowerRole, units};
+use crate::{Contract, DataRole, PowerRole, SwapType, units};
 
 #[cfg(test)]
 mod tests;
@@ -31,15 +30,6 @@ enum Mode {
     Spr,
     /// A Power Delivery mode of operation where maximum allowable voltage is 48V.
     Epr,
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-enum Contract {
-    #[default]
-    Safe5V,
-    _Implicit, // FIXME: Only present after fast role swap, yet unsupported. Limited to max. type C current.
-    TransitionToExplicit,
-    Explicit,
 }
 
 /// Sink states.
@@ -55,32 +45,107 @@ enum State {
     TransitionSink(request::PowerSource),
     /// Ready state. The bool indicates if we entered due to receiving a Wait message,
     /// which requires running SinkRequestTimer before allowing re-request.
-    Ready(request::PowerSource, bool),
-    SendNotSupported(request::PowerSource),
+    Ready(bool),
+    SendNotSupported,
+    NotSupportedReceived,
     SendSoftReset,
     SoftReset,
     HardReset,
     TransitionToDefault,
     /// Give sink capabilities. The Mode indicates whether to send Sink_Capabilities (Spr)
     /// or EPR_Sink_Capabilities (Epr) per spec 8.3.3.3.10.
-    GiveSinkCap(Mode, request::PowerSource),
-    GetSourceCap(Mode, request::PowerSource),
+    GiveSinkCap(Mode),
+    GetSourceCap(Mode),
+    /// 8.3.3.19 Dual-Role Port (DRP) States
+    DrpSwap(SwapState),
+    /// 8.3.3.20 Vconn Swap
+    VconnSwap(VcsState),
+    /// EPR states
+    EprMode(EprState),
+    /// Custom state to signal exit out of sink to source from a power swap
+    PrSwapToSourceStartup,
+    ErrorRecovery,
+}
 
-    // EPR states
-    EprModeEntry(request::PowerSource, units::Power),
-    EprEntryWaitForResponse(request::PowerSource),
-    EprWaitForCapabilities(request::PowerSource),
-    EprSendExit,
-    EprExitReceived(request::PowerSource),
-    EprKeepAlive(request::PowerSource),
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+/// Dual Role Port Swap States
+enum SwapState {
+    Data(DataRoleSwap),
+    Power(PowerRoleSwap),
+    FastPower(FastPowerRoleSwap),
+}
+
+/// State during a Data Role Swap execution (for both directions)
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+enum DataRoleSwap {
+    Evaluate,
+    Accept,
+    Change,
+    Send,
+    Reject,
+}
+
+/// State during a Power Role Swap execution
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+enum PowerRoleSwap {
+    Evaluate,
+    Accept,
+    TransitionToOff,
+    AssertRp,
+    SourceOn,
+    Send,
+    Reject,
+}
+
+/// State during a Fast Power Role Swap execution
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+enum FastPowerRoleSwap {
+    // TODO: Determine how to best poll & enter FrSwaps
+    Start,
+    Send,
+    TransitionToOff,
+    VbusApplied,
+    AssertRp,
+    SourceOn,
+}
+
+/// 8.3.3.20 Vconn Swap. State during a Vconn Swap execution
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+enum VcsState {
+    SendSwap,
+    EvaluateSwap,
+    AcceptSwap,
+    RejectSwap,
+    WaitForVconn,
+    TurnOffVconn,
+    TurnOnVconn,
+    SendPsRdy,
+    // FIXME: For now, forcing a different state traversla, resulting in this being unused
+    #[allow(unused)]
+    ForceVconn
+}
+
+#[derive(Debug, Clone, Copy)]
+enum EprState {
+    Entry(units::Power),
+    EntryWaitForResponse,
+    WaitForCapabilities,
+    SendExit,
+    ExitReceived,
+    KeepAlive,
 }
 
 /// Implementation of the sink policy engine.
 /// See spec, [8.3.3.3]
 #[derive(Debug)]
-pub struct Sink<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> {
-    device_policy_manager: DPM,
-    protocol_layer: SinkProtocolLayer<DRIVER, TIMER>,
+pub struct Sink<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> {
+    device_policy_manager: &'a mut DPM,
+    protocol_layer: SinkProtocolLayer<'a, DRIVER, TIMER>,
     contract: Contract,
     hard_reset_counter: Counter,
     source_capabilities: Option<SourceCapabilities>,
@@ -91,6 +156,8 @@ pub struct Sink<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> {
     /// Source_Capabilities message that was not requested via Get_Source_Cap
     /// shall trigger a Hard Reset.
     get_source_cap_pending: bool,
+    dual_role: bool,
+    vconn_source: bool,
 
     _timer: PhantomData<TIMER>,
 }
@@ -101,6 +168,10 @@ pub struct Sink<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> {
 pub enum Error {
     /// The port partner is unresponsive.
     PortPartnerUnresponsive,
+    /// Entered ErrorRecovery mode. This requests a disconnect.
+    ReconnectionRequired,
+    /// FIXME: Easiest way to signal to device to swap to source
+    SwapToSource,
     /// A protocol error has occured.
     Protocol(ProtocolError),
 }
@@ -111,15 +182,15 @@ impl From<ProtocolError> for Error {
     }
 }
 
-impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER, DPM> {
+impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM> {
     /// Create a fresh protocol layer with initial state.
-    fn new_protocol_layer(driver: DRIVER) -> SinkProtocolLayer<DRIVER, TIMER> {
+    fn new_protocol_layer(driver: &'a mut DRIVER) -> SinkProtocolLayer<'a, DRIVER, TIMER> {
         let header = Header::new_template(DataRole::Ufp, PowerRole::Sink, SpecificationRevision::R3_X);
         SinkProtocolLayer::new(driver, header)
     }
 
     /// Create a new sink policy engine with a given `driver`.
-    pub fn new(driver: DRIVER, device_policy_manager: DPM) -> Self {
+    pub fn new(driver: &'a mut DRIVER, device_policy_manager: &'a mut DPM) -> Self {
         Self {
             device_policy_manager,
             protocol_layer: Self::new_protocol_layer(driver),
@@ -129,12 +200,31 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
             source_capabilities: None,
             mode: Mode::Spr,
             get_source_cap_pending: false,
+            dual_role: false,
+            vconn_source: false,
+            _timer: PhantomData,
+        }
+    }
+
+    /// Create a new dual role sink policy engine with a given `driver`.
+    pub fn new_dual_role(driver: &'a mut DRIVER, device_policy_manager: &'a mut DPM) -> Self {
+        Self {
+            device_policy_manager,
+            protocol_layer: Self::new_protocol_layer(driver),
+            state: State::Discovery,
+            contract: Default::default(),
+            hard_reset_counter: Counter::new(crate::counters::CounterType::HardReset),
+            source_capabilities: None,
+            mode: Mode::Spr,
+            get_source_cap_pending: false,
+            dual_role: true,
+            vconn_source: false,
             _timer: PhantomData,
         }
     }
 
     /// Set a new driver when re-attached.
-    pub fn re_attach(&mut self, driver: DRIVER) {
+    pub fn re_attach(&mut self, driver: &'a mut DRIVER) {
         self.protocol_layer = Self::new_protocol_layer(driver);
     }
 
@@ -147,6 +237,12 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
 
         if let Err(Error::Protocol(protocol_error)) = result {
             let new_state = match (&self.mode, &self.state, protocol_error) {
+                (_, State::DrpSwap(SwapState::FastPower(_)), _) => {
+                    // Any errors after a `Fast Power Swap` has been asserted propogate to `ErrorRecovery`
+                    // This is because the `Source` lost power before the fast swapping `Sink` could keep it alive.
+                    Some(State::ErrorRecovery)
+                }
+
                 // Handle when hard reset is signaled by the driver itself.
                 (_, _, ProtocolError::RxError(RxError::HardReset) | ProtocolError::TxError(TxError::HardReset)) => {
                     Some(State::TransitionToDefault)
@@ -176,14 +272,22 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                 // shall trigger a Hard Reset, not a Soft Reset.
                 (_, State::TransitionSink(_), _) => Some(State::HardReset),
 
+                (
+                    _,
+                    State::DrpSwap(SwapState::Power(PowerRoleSwap::Send)),
+                    ProtocolError::RxError(RxError::ReceiveTimeout),
+                ) => Some(State::Ready(false)),
+
+                (_, State::VconnSwap(VcsState::SendSwap), ProtocolError::RxError(RxError::ReceiveTimeout)) => Some(State::Ready(false)),
+
                 // Unexpected messages indicate a protocol error and demand a soft reset.
                 // Per spec 6.8.1 Table 6.72 (for non-power-transitioning states).
                 // Note: This must come AFTER TransitionSink check above.
                 (_, _, ProtocolError::UnexpectedMessage) => Some(State::SendSoftReset),
 
                 // Per spec Table 6.72: Unsupported messages in Ready state get Not_Supported response.
-                (_, State::Ready(power_source, _), ProtocolError::RxError(RxError::UnsupportedMessage)) => {
-                    Some(State::SendNotSupported(*power_source))
+                (_, State::Ready(_), ProtocolError::RxError(RxError::UnsupportedMessage)) => {
+                    Some(State::SendNotSupported)
                 }
 
                 // Per spec 6.6.9.1: Transmission failure (no GoodCRC after retries) triggers Soft Reset.
@@ -229,7 +333,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
     /// Per spec section 6.4.1.2.2, after a Soft Reset while in EPR Mode, the source sends
     /// EPR_Source_Capabilities. Therefore this function must handle both message types.
     async fn wait_for_source_capabilities(
-        protocol_layer: &mut SinkProtocolLayer<DRIVER, TIMER>,
+        protocol_layer: &mut SinkProtocolLayer<'a, DRIVER, TIMER>,
     ) -> Result<SourceCapabilities, Error> {
         let message = protocol_layer.wait_for_source_capabilities().await?;
         trace!("Source capabilities: {:?}", message);
@@ -300,11 +404,11 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     (Contract::Safe5V, ControlMessageType::Wait | ControlMessageType::Reject) => {
                         State::WaitForCapabilities
                     }
-                    (Contract::Explicit, ControlMessageType::Reject) => State::Ready(*power_source, false),
-                    (Contract::Explicit, ControlMessageType::Wait) => {
+                    (Contract::Explicit(_), ControlMessageType::Reject) => State::Ready(false),
+                    (Contract::Explicit(_), ControlMessageType::Wait) => {
                         // Per spec 8.3.3.3.7: On entry to Ready as result of Wait,
                         // initialize and run SinkRequestTimer.
-                        State::Ready(*power_source, true)
+                        State::Ready(true)
                     }
                     _ => unreachable!(),
                 }
@@ -322,9 +426,10 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
 
                 self.contract = Contract::TransitionToExplicit;
                 self.device_policy_manager.transition_power(power_source).await;
-                State::Ready(*power_source, false)
+                self.contract = Contract::Explicit(*power_source);
+                State::Ready(false)
             }
-            State::Ready(power_source, after_wait) => {
+            State::Ready(after_wait) => {
                 // TODO: Entry: Init. and run DiscoverIdentityTimer(4)
                 // TODO: Entry: Send GetSinkCap message if sink supports fast role swap
                 // TODO: Exit: If initiating an AMS, notify protocol layer
@@ -334,12 +439,15 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                 //   before allowing re-request. On timeout, transition to SelectCapability.
                 // - SinkPPSPeriodicTimer: triggers SelectCapability in SPR PPS mode
                 // - SinkEPRKeepAliveTimer: triggers EprKeepAlive in EPR mode
-                self.contract = Contract::Explicit;
 
                 let receive_fut = self.protocol_layer.receive_message();
                 let event_fut = self
                     .device_policy_manager
                     .get_event(self.source_capabilities.as_ref().unwrap());
+                let power_source = match self.contract {
+                    Contract::Explicit(p) => p,
+                    _ => unreachable!(),
+                };
                 let pps_periodic_fut = async {
                     match power_source {
                         PowerSource::Pps(_) => TimerType::get_timer::<TIMER>(TimerType::SinkPPSPeriodic).await,
@@ -405,55 +513,76 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                             }
                             MessageType::Data(DataMessageType::EprMode) => {
                                 // Handle source exit notification.
-                                State::EprExitReceived(*power_source)
+                                State::EprMode(EprState::ExitReceived)
                             }
+                            MessageType::Control(ControlMessageType::PrSwap) => match self.dual_role {
+                                true => State::DrpSwap(SwapState::Power(PowerRoleSwap::Evaluate)),
+                                false => State::SendNotSupported,
+                            },
+                            MessageType::Control(ControlMessageType::DrSwap) => match self.dual_role {
+                                true => State::DrpSwap(SwapState::Data(DataRoleSwap::Evaluate)),
+                                false => State::SendNotSupported,
+                            },
                             // Per spec 8.3.3.3.7: Get_Sink_Cap → GiveSinkCap (send Sink_Capabilities)
-                            MessageType::Control(ControlMessageType::GetSinkCap) => {
-                                State::GiveSinkCap(Mode::Spr, *power_source)
-                            }
+                            MessageType::Control(ControlMessageType::GetSinkCap) => State::GiveSinkCap(Mode::Spr),
+                            MessageType::Control(ControlMessageType::VconnSwap) => State::VconnSwap(VcsState::EvaluateSwap),
                             // Per spec 8.3.3.3.7: EPR_Get_Sink_Cap → GiveSinkCap (send EPR_Sink_Capabilities)
                             MessageType::Extended(ExtendedMessageType::ExtendedControl) => {
                                 if let Some(Payload::Extended(extended::Extended::ExtendedControl(ctrl))) =
                                     &message.payload
                                 {
                                     if ctrl.message_type() == ExtendedControlMessageType::EprGetSinkCap {
-                                        State::GiveSinkCap(Mode::Epr, *power_source)
+                                        State::GiveSinkCap(Mode::Epr)
                                     } else {
-                                        State::SendNotSupported(*power_source)
+                                        State::SendNotSupported
                                     }
                                 } else {
-                                    State::SendNotSupported(*power_source)
+                                    State::SendNotSupported
                                 }
                             }
-                            _ => State::SendNotSupported(*power_source),
+                            _ => State::SendNotSupported,
                         }
                     }
                     // Event from device policy manager.
                     Either3::Second(event) => match event {
-                        Event::RequestSprSourceCapabilities => State::GetSourceCap(Mode::Spr, *power_source),
-                        Event::RequestEprSourceCapabilities => State::GetSourceCap(Mode::Epr, *power_source),
-                        Event::EnterEprMode(pdp) => State::EprModeEntry(*power_source, pdp),
-                        Event::ExitEprMode => State::EprSendExit,
+                        Event::RequestSprSourceCapabilities => State::GetSourceCap(Mode::Spr),
+                        Event::RequestEprSourceCapabilities => State::GetSourceCap(Mode::Epr),
+                        Event::EnterEprMode(pdp) => State::EprMode(EprState::Entry(pdp)),
+                        Event::ExitEprMode => State::EprMode(EprState::SendExit),
                         Event::RequestPower(power_source) => State::SelectCapability(power_source),
-                        Event::None => State::Ready(*power_source, false),
+                        Event::RequestVconnSwap => State::VconnSwap(VcsState::SendSwap),
+                        Event::FastPowerRoleSwap => match self.dual_role {
+                            true => State::DrpSwap(SwapState::FastPower(FastPowerRoleSwap::Send)),
+                            false => State::ErrorRecovery,
+                        },
+                        Event::RequestPowerRoleSwap => State::DrpSwap(SwapState::Power(PowerRoleSwap::Send)),
+                        Event::RequestDataRoleSwap => State::DrpSwap(SwapState::Data(DataRoleSwap::Send)),
+                        Event::None => State::Ready(false),
                     },
                     // Timer timeout handling
                     Either3::Third(timeout_source) => match timeout_source {
                         // PPS periodic timeout -> select capability again as keep-alive.
-                        Either3::First(_) => State::SelectCapability(*power_source),
+                        Either3::First(_) => State::SelectCapability(power_source),
                         // EPR keep-alive timeout
-                        Either3::Second(_) => State::EprKeepAlive(*power_source),
+                        Either3::Second(_) => State::EprMode(EprState::KeepAlive),
                         // SinkRequest timeout -> re-request power after Wait response
-                        Either3::Third(_) => State::SelectCapability(*power_source),
+                        Either3::Third(_) => State::SelectCapability(power_source),
                     },
                 }
             }
-            State::SendNotSupported(power_source) => {
+            State::SendNotSupported => {
                 self.protocol_layer
                     .transmit_control_message(ControlMessageType::NotSupported)
                     .await?;
 
-                State::Ready(*power_source, false)
+                State::Ready(false)
+            }
+            State::NotSupportedReceived => {
+                // FIXME: This unwrap scares me
+                self.device_policy_manager
+                    .inform(&self.source_capabilities.clone().unwrap(), Info::None)
+                    .await;
+                State::Ready(false)
             }
             State::SendSoftReset => {
                 self.protocol_layer.reset();
@@ -536,7 +665,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
 
                 State::Startup
             }
-            State::GiveSinkCap(response_mode, power_source) => {
+            State::GiveSinkCap(response_mode) => {
                 // Per USB PD Spec R3.2 Section 8.3.3.3.10:
                 // - Send Sink_Capabilities when Get_Sink_Cap was received
                 // - Send EPR_Sink_Capabilities when EPR_Get_Sink_Cap was received
@@ -550,9 +679,9 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     }
                 }
 
-                State::Ready(*power_source, false)
+                State::Ready(false)
             }
-            State::GetSourceCap(requested_mode, power_source) => {
+            State::GetSourceCap(requested_mode) => {
                 // Per USB PD Spec R3.2 Section 8.3.3.3.12 (PE_SNK_Get_Source_Cap):
                 // - Send Get_Source_Cap (SPR) or EPR_Get_Source_Cap (EPR)
                 // - Start SenderResponseTimer
@@ -599,7 +728,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     Err(ProtocolError::RxError(RxError::ReceiveTimeout)) => {
                         // Inform DPM of timeout (no capabilities received)
                         warn!("Get_Source_Cap timeout, returning to Ready");
-                        self.state = State::Ready(*power_source, false);
+                        self.state = State::Ready(false);
                         return Ok(());
                     }
                     Err(e) => return Err(e.into()),
@@ -630,15 +759,361 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     _ => unreachable!(),
                 };
 
-                self.device_policy_manager.inform(&capabilities).await;
+                self.device_policy_manager.inform(&capabilities, Info::None).await;
 
                 if mode_matches {
                     State::EvaluateCapabilities(capabilities)
                 } else {
-                    State::Ready(*power_source, false)
+                    State::Ready(false)
                 }
             }
-            State::EprModeEntry(power_source, operational_pdp) => {
+
+            // 8.3.3.19 Dual-Role Port States
+            State::DrpSwap(swap_state) => match swap_state {
+                SwapState::Data(dr) => self.execute_data_role_swap_state(*dr).await?,
+                SwapState::Power(pr) => self.execute_power_role_swap_state(*pr).await?,
+                SwapState::FastPower(fr) => self.execute_fast_power_role_swap_state(*fr).await?,
+            },
+
+            // 8.3.3.20 Sink Vconn Swap
+            State::VconnSwap(vcs_state) => {
+                self.execute_vconn_swap_state(*vcs_state).await?
+            }
+
+            // 8.3.3.26.2/4 Sink EPR Mode Entry/Exit, 8.3.3.3.3, 8.3.3.3.11
+            State::EprMode(epr_state) => {
+                self.execute_epr_state(*epr_state).await?
+            }
+
+            State::PrSwapToSourceStartup => {
+                // FIXME: Better way to transition to Source?
+                Err(Error::SwapToSource)?
+            }
+
+            // 8.3.3.28.1
+            State::ErrorRecovery => {
+                error!("Entered Error Recovery state! Reconnection required.");
+                Err(Error::ReconnectionRequired)?
+            }
+        };
+
+        self.state = new_state;
+
+        Ok(())
+    }
+
+    async fn execute_data_role_swap_state(&mut self, state: DataRoleSwap) -> Result<State, Error> {
+        match state {
+            // 8.3.3.19.2.1 (PE_DRS_DFP_UFP_Evaluate_Swap, PE_DRS_UFP_DFP_Evaluate_Swap):
+            DataRoleSwap::Evaluate => match self.device_policy_manager.evaluate_swap_request(SwapType::Data).await {
+                true => Ok(State::DrpSwap(SwapState::Data(DataRoleSwap::Accept))),
+                false => Ok(State::DrpSwap(SwapState::Data(DataRoleSwap::Reject))),
+            },
+            // 8.3.3.19.1.3 (PE_DRS_DFP_UFP_Accept_Swap, PE_DRS_UFP_DFP_Accept_Swap):
+            DataRoleSwap::Accept => {
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::Accept)
+                    .await?;
+                Ok(State::DrpSwap(SwapState::Data(DataRoleSwap::Change)))
+            }
+            // 8.3.3.19.1.4 (PE_DRS_DFP_UFP_Change_to_UFP_Swap, PE_DRS_UFP_DFP_Change_to_DFP_Swap):
+            DataRoleSwap::Change => {
+                let new_role = DataRole::from(!bool::from(self.protocol_layer.header().port_data_role()));
+                self.device_policy_manager.swap_data_role(new_role).await;
+                Ok(State::Ready(false))
+            }
+            // 8.3.3.19.1.5 (PE_DRS_DFP_UFP_Send_Swap, PE_DRS_UFP_DFP_Send_Swap):
+            DataRoleSwap::Send => {
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::DrSwap)
+                    .await?;
+
+                let message = self
+                    .protocol_layer
+                    .receive_message_type(
+                        &[
+                            MessageType::Control(ControlMessageType::Accept),
+                            MessageType::Control(ControlMessageType::Reject),
+                            MessageType::Control(ControlMessageType::Wait),
+                        ],
+                        TimerType::SenderResponse,
+                    )
+                    .await?;
+
+                match message.header.message_type() {
+                    MessageType::Control(ControlMessageType::Accept) => {
+                        Ok(State::DrpSwap(SwapState::Data(DataRoleSwap::Change)))
+                    }
+
+                    MessageType::Control(ControlMessageType::Reject) => Ok(State::Ready(false)),
+                    MessageType::Control(ControlMessageType::Wait) => Ok(State::Ready(true)),
+
+                    _ => Err(Error::Protocol(ProtocolError::UnexpectedMessage)),
+                }
+            }
+            // 8.3.3.19.1.6 (PE_DRS_DFP_UFP_Reject_Swap, PE_DRS_UFP_DFP_Reject_Swap):
+            DataRoleSwap::Reject => {
+                // FIXME: Wait Message logic
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::Reject)
+                    .await?;
+                Ok(State::Ready(false))
+            }
+        }
+    }
+
+    async fn execute_power_role_swap_state(&mut self, state: PowerRoleSwap) -> Result<State, Error> {
+        match state {
+            // 8.3.3.19.4.2 (PE_PRS_SNK_SRC_Evaluate_Swap):
+            PowerRoleSwap::Evaluate => match self.device_policy_manager.evaluate_swap_request(SwapType::Power).await {
+                true => Ok(State::DrpSwap(SwapState::Power(PowerRoleSwap::Accept))),
+                false => Ok(State::DrpSwap(SwapState::Power(PowerRoleSwap::Reject))),
+            },
+            // 8.3.3.19.4.3 (PE_PRS_SNK_SRC_Accept_Swap):
+            PowerRoleSwap::Accept => {
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::Accept)
+                    .await?;
+                Ok(State::DrpSwap(SwapState::Power(PowerRoleSwap::TransitionToOff)))
+            }
+            // 8.3.3.19.4.4 (PE_PRS_SNK_SRC_Transition_to_off):
+            PowerRoleSwap::TransitionToOff => {
+                self.device_policy_manager.disable().await;
+
+                let timer_type = match self.mode {
+                    Mode::Spr => TimerType::PSSourceOffSpr,
+                    Mode::Epr => TimerType::PSSourceOffEpr,
+                };
+
+                self.protocol_layer
+                    .receive_message_type(&[MessageType::Control(ControlMessageType::PsRdy)], timer_type)
+                    .await?;
+
+                Ok(State::DrpSwap(SwapState::Power(PowerRoleSwap::AssertRp)))
+            }
+            // 8.3.3.19.4.5 (PE_PRS_SNK_SRC_Assert_Rp):
+            PowerRoleSwap::AssertRp => {
+                self.device_policy_manager.cc_source().await;
+                Ok(State::DrpSwap(SwapState::Power(PowerRoleSwap::SourceOn)))
+            }
+            // 8.3.3.19.4.6 (PE_PRS_SNK_SRC_Source_on):
+            PowerRoleSwap::SourceOn => {
+                self.device_policy_manager.source_on().await;
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::PsRdy)
+                    .await?;
+                Ok(State::PrSwapToSourceStartup)
+            }
+            // 8.3.3.19.4.7 (PE_PRS_SNK_SRC_Send_Swap):
+            PowerRoleSwap::Send => {
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::PrSwap)
+                    .await?;
+
+                let message = self
+                    .protocol_layer
+                    .receive_message_type(
+                        &[
+                            MessageType::Control(ControlMessageType::Accept),
+                            MessageType::Control(ControlMessageType::Reject),
+                            MessageType::Control(ControlMessageType::Wait),
+                        ],
+                        TimerType::SenderResponse,
+                    )
+                    .await?;
+
+                match message.header.message_type() {
+                    MessageType::Control(ControlMessageType::Accept) => {
+                        Ok(State::DrpSwap(SwapState::Power(PowerRoleSwap::TransitionToOff)))
+                    }
+
+                    MessageType::Control(ControlMessageType::Reject)
+                    | MessageType::Control(ControlMessageType::Wait) => Ok(State::Ready(false)),
+
+                    _ => Err(Error::Protocol(ProtocolError::UnexpectedMessage)),
+                }
+            }
+            // 8.3.3.19.4.8 (PE_PRS_SNK_SRC_Reject_Swap):
+            PowerRoleSwap::Reject => {
+                // FIXME: Wait Message logic
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::Reject)
+                    .await?;
+                Ok(State::Ready(false))
+            }
+        }
+    }
+
+    async fn execute_fast_power_role_swap_state(&mut self, state: FastPowerRoleSwap) -> Result<State, Error> {
+        match state {
+            // 8.3.3.19.6.1 (PE_FRS_SNK_SRC_Start_AMS):
+            FastPowerRoleSwap::Start => Ok(State::DrpSwap(SwapState::FastPower(FastPowerRoleSwap::Send))),
+            // 8.3.3.19.6.2 (PE_FRS_SNK_SRC_Send_Swap):
+            FastPowerRoleSwap::Send => {
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::FrSwap)
+                    .await?;
+
+                self.protocol_layer
+                    .receive_message_type(
+                        &[MessageType::Control(ControlMessageType::Accept)],
+                        TimerType::SenderResponse,
+                    )
+                    .await?;
+
+                Ok(State::DrpSwap(SwapState::FastPower(FastPowerRoleSwap::TransitionToOff)))
+            }
+            // 8.3.3.19.6.3 (PE_FRS_SNK_SRC_Transition_to_off):
+            FastPowerRoleSwap::TransitionToOff => {
+                self.device_policy_manager.disable().await;
+
+                let timer_type = match self.mode {
+                    Mode::Spr => TimerType::PSSourceOffSpr,
+                    Mode::Epr => TimerType::PSSourceOffEpr,
+                };
+
+                self.protocol_layer
+                    .receive_message_type(&[MessageType::Control(ControlMessageType::PsRdy)], timer_type)
+                    .await?;
+
+                Ok(State::DrpSwap(SwapState::FastPower(FastPowerRoleSwap::VbusApplied)))
+            }
+            // 8.3.3.19.6.4 (PE_FRS_SNK_SRC_Vbus_Applied):
+            FastPowerRoleSwap::VbusApplied => {
+                self.device_policy_manager.source_on().await;
+                Ok(State::DrpSwap(SwapState::FastPower(FastPowerRoleSwap::AssertRp)))
+            }
+            // 8.3.3.19.6.5 (PE_FRS_SNK_SRC_Assert_Rp):
+            FastPowerRoleSwap::AssertRp => {
+                self.device_policy_manager.cc_source().await;
+                Ok(State::DrpSwap(SwapState::FastPower(FastPowerRoleSwap::SourceOn)))
+            }
+            // 8.3.3.19.6.6 (PE_FRS_SNK_SRC_Source_on):
+            FastPowerRoleSwap::SourceOn => {
+                // FIXME: Determine if using .source_on() for `VbusApplied` is correct.
+                // self.device_policy_manager.source_on().await;
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::PsRdy)
+                    .await?;
+                Ok(State::PrSwapToSourceStartup)
+            }
+        }
+    }
+
+    // 8.3.3.20 Sink Vconn Swap
+    async fn execute_vconn_swap_state(&mut self, state: VcsState) -> Result<State, Error> {
+        let new_state = match state {
+            // 8.3.3.20.1 (PE_VCS_Send_Swap):
+            VcsState::SendSwap => {
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::VconnSwap)
+                    .await?;
+
+                let message = self
+                    .protocol_layer
+                    .receive_message_type(
+                        &[
+                            MessageType::Control(ControlMessageType::Accept),
+                            MessageType::Control(ControlMessageType::Reject),
+                            MessageType::Control(ControlMessageType::Wait),
+                            MessageType::Control(ControlMessageType::NotSupported),
+                        ],
+                        TimerType::SenderResponse,
+                    )
+                    .await?;
+
+                match message.header.message_type() {
+                    MessageType::Control(ControlMessageType::Accept) => match self.vconn_source {
+                        true => State::VconnSwap(VcsState::WaitForVconn),
+                        false => State::VconnSwap(VcsState::TurnOnVconn),
+                    },
+                    MessageType::Control(ControlMessageType::Reject) => State::Ready(false),
+                    MessageType::Control(ControlMessageType::Wait) => State::Ready(false), // FIXME: inform DPM and change to `true`
+                    // May also transition to ForceVconn if NotSupported message and port presently not vconn source
+                    MessageType::Control(ControlMessageType::NotSupported) => State::NotSupportedReceived,
+                    _ => unreachable!(),
+                }
+            }
+            // 8.3.3.20.2 (PE_VCS_Evaluate_Swap):
+            VcsState::EvaluateSwap => {
+                let request_accepted = self.device_policy_manager.evaluate_vconn_swap_request().await;
+
+                if request_accepted {
+                    State::VconnSwap(VcsState::AcceptSwap)
+                } else {
+                    State::VconnSwap(VcsState::RejectSwap)
+                }
+            }
+            // 8.3.3.20.3 (PE_VCS_Accept_Swap):
+            VcsState::AcceptSwap => {
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::Accept)
+                    .await?;
+
+                if self.vconn_source {
+                    State::VconnSwap(VcsState::WaitForVconn)
+                } else {
+                    State::VconnSwap(VcsState::TurnOnVconn)
+                }
+            },
+            // 8.3.3.20.4 (PE_VCS_Reject_Swap):
+            VcsState::RejectSwap => {
+                // FIXME: Wait Message logic
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::Reject)
+                    .await?;
+
+                State::Ready(false)
+            },
+            // 8.3.3.20.5 (PE_VCS_Wait_for_Vconn):
+            VcsState::WaitForVconn => {
+                self.protocol_layer
+                    .receive_message_type(&[MessageType::Control(ControlMessageType::PsRdy)], TimerType::VCONNOn)
+                    .await?;
+
+                State::VconnSwap(VcsState::TurnOffVconn)
+            },
+            // 8.3.3.20.6 (PE_VCS_Turn_Off_Vconn):
+            VcsState::TurnOffVconn => {
+                self.device_policy_manager
+                    .drive_vconn(false)
+                    .await
+                    .map_err(|_| Error::ReconnectionRequired)?;
+
+                State::Ready(false)
+            },
+            // 8.3.3.20.7 (PE_VCS_Turn_On_Vconn):
+            VcsState::TurnOnVconn => {
+                self.device_policy_manager
+                    .drive_vconn(true)
+                    .await
+                    .map_err(|_| Error::ReconnectionRequired)?;
+                State::VconnSwap(VcsState::SendPsRdy)
+            },
+            // 8.3.3.20.8 (PE_VCS_Send_PS_Rdy):
+            VcsState::SendPsRdy => {
+                self.protocol_layer
+                    .transmit_control_message(ControlMessageType::PsRdy)
+                    .await?;
+                State::Ready(false)
+            },
+            // 8.3.3.20.9 (PE_VCS_Force_Vconn):
+            VcsState::ForceVconn => {
+                self.device_policy_manager
+                    .drive_vconn(true)
+                    .await
+                    .map_err(|_| Error::ReconnectionRequired)?;
+                State::Ready(false)
+            },
+        };
+
+        Ok(new_state)
+    }
+
+    async fn execute_epr_state(&mut self, state: EprState) -> Result<State, Error> {
+        let new_state = match state {
+            // 8.3.3.26.2.1 (PE_SNK_Send_EPR_Mode_Entry):
+            EprState::Entry(operational_pdp) => {
                 // Request entry into EPR mode.
                 // Per spec 8.3.3.26.2.1 (PE_SNK_Send_EPR_Mode_Entry), sink sends EPR_Mode (Enter)
                 // and starts SenderResponseTimer and SinkEPREnterTimer.
@@ -670,14 +1145,14 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                 match epr_mode.action() {
                     Action::EnterAcknowledged => {
                         // Source acknowledged, now wait for EnterSucceeded
-                        State::EprEntryWaitForResponse(*power_source)
+                        State::EprMode(EprState::EntryWaitForResponse)
                     }
                     Action::EnterSucceeded => {
                         // Source skipped EnterAcknowledged and went directly to EnterSucceeded
                         self.mode = Mode::Epr;
-                        State::EprWaitForCapabilities(*power_source)
+                        State::EprMode(EprState::WaitForCapabilities)
                     }
-                    Action::Exit => State::EprExitReceived(*power_source),
+                    Action::Exit => State::EprMode(EprState::ExitReceived),
                     Action::EnterFailed => {
                         // Per spec 8.3.3.26.2.1: EnterFailed → Soft Reset
                         // Notify DPM of the failure reason before soft reset
@@ -689,7 +1164,8 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     _ => State::SendSoftReset,
                 }
             }
-            State::EprEntryWaitForResponse(power_source) => {
+            // 8.3.3.26.2.2 (PE_SNK_EPR_Mode_Wait_For_Response):
+            EprState::EntryWaitForResponse => {
                 // Wait for EnterSucceeded after receiving EnterAcknowledged.
                 // Per spec 8.3.3.26.2.2 (PE_SNK_EPR_Mode_Wait_For_Response), use SinkEPREnterTimer
                 // for the overall timeout while source performs cable discovery.
@@ -707,9 +1183,9 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                         // EPR mode entry succeeded. Per spec Table 8.39 step 21-29,
                         // source will automatically send EPR_Source_Capabilities after this.
                         self.mode = Mode::Epr;
-                        State::EprWaitForCapabilities(*power_source)
+                        State::EprMode(EprState::WaitForCapabilities)
                     }
-                    Action::Exit => State::EprExitReceived(*power_source),
+                    Action::Exit => State::EprMode(EprState::ExitReceived),
                     Action::EnterFailed => {
                         // Per spec 8.3.3.26.2.2: EnterFailed → Soft Reset
                         // Notify DPM of the failure reason before soft reset
@@ -721,7 +1197,8 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     _ => State::SendSoftReset,
                 }
             }
-            State::EprWaitForCapabilities(_power_source) => {
+            // EPR Mode PE_SNK_Wait_for_Capabilities
+            EprState::WaitForCapabilities => {
                 // After successful EPR mode entry, source automatically sends EPR_Source_Capabilities.
                 // This may be a chunked extended message that requires assembly.
                 // Wait for the capabilities and evaluate them.
@@ -739,14 +1216,16 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                         State::HardReset
                     }
                 }
-            }
-            State::EprSendExit => {
+            },
+            // 8.3.3.26.4.1 (PE_SNK_Send_EPR_Mode_Exit):
+            EprState::SendExit => {
                 // Inform partner we are exiting EPR.
                 self.protocol_layer.transmit_epr_mode(Action::Exit, 0).await?;
                 self.mode = Mode::Spr;
                 State::WaitForCapabilities
-            }
-            State::EprExitReceived(power_source) => {
+            },
+            // 8.3.3.26.4.2 (PE_SNK_EPR_Mode_Exit_Received):
+            EprState::ExitReceived => {
                 // Per USB PD Spec R3.2 Section 8.3.3.26.4.2 (PE_SNK_EPR_Mode_Exit_Received):
                 // - If in an Explicit Contract with an SPR (A)PDO → WaitForCapabilities
                 // - If NOT in an Explicit Contract with an SPR (A)PDO → HardReset
@@ -755,12 +1234,11 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                 // In EPR mode, requests use EprRequest which contains the RDO with object position.
                 self.mode = Mode::Spr;
 
-                let is_epr_pdo_contract = match power_source {
-                    PowerSource::EprRequest(epr) => {
+                let is_epr_pdo_contract = match self.contract {
+                    Contract::Explicit(PowerSource::EprRequest(epr)) => {
                         // Extract object position from RDO (bits 28-31)
                         epr.object_position() >= 8
                     }
-                    // Non-EprRequest variants are only used in SPR mode, so always SPR PDOs
                     _ => false,
                 };
 
@@ -769,9 +1247,9 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                 } else {
                     State::WaitForCapabilities
                 }
-            }
-            State::EprKeepAlive(power_source) => {
-                // Per spec 8.3.3.3.11 (PE_SNK_EPR_Keep_Alive):
+            },
+            // 8.3.3.3.11 (PE_SNK_EPR_Keep_Alive):
+            EprState::KeepAlive => {
                 // - Entry: Send EPR_KeepAlive message, start SenderResponseTimer
                 // - On EPR_KeepAlive_Ack: transition to Ready (which restarts SinkEPRKeepAliveTimer)
                 // - On timeout: transition to HardReset
@@ -794,21 +1272,19 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                                 == crate::protocol_layer::message::extended::extended_control::ExtendedControlMessageType::EprKeepAliveAck
                             {
                                 self.mode = Mode::Epr;
-                                State::Ready(*power_source, false)
+                                State::Ready(false)
                             } else {
-                                State::SendNotSupported(*power_source)
+                                State::SendNotSupported
                             }
                         } else {
-                            State::SendNotSupported(*power_source)
+                            State::SendNotSupported
                         }
                     }
                     Err(_) => State::HardReset,
                 }
-            }
+            },
         };
 
-        self.state = new_state;
-
-        Ok(())
+        Ok(new_state)
     }
 }

--- a/usbpd/src/sink/policy_engine/mod.rs
+++ b/usbpd/src/sink/policy_engine/mod.rs
@@ -144,9 +144,9 @@ enum EprState {
 /// Implementation of the sink policy engine.
 /// See spec, [8.3.3.3]
 #[derive(Debug)]
-pub struct Sink<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> {
-    device_policy_manager: &'a mut DPM,
-    protocol_layer: SinkProtocolLayer<'a, DRIVER, TIMER>,
+pub struct Sink<DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> {
+    device_policy_manager: DPM,
+    protocol_layer: SinkProtocolLayer<DRIVER, TIMER>,
     contract: Contract,
     hard_reset_counter: Counter,
     source_capabilities: Option<SourceCapabilities>,
@@ -181,15 +181,15 @@ impl From<ProtocolError> for Error {
     }
 }
 
-impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM> {
+impl<DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<DRIVER, TIMER, DPM> {
     /// Create a fresh protocol layer with initial state.
-    fn new_protocol_layer(driver: &'a mut DRIVER) -> SinkProtocolLayer<'a, DRIVER, TIMER> {
+    fn new_protocol_layer(driver: DRIVER) -> SinkProtocolLayer<DRIVER, TIMER> {
         let header = Header::new_template(DataRole::Ufp, PowerRole::Sink, SpecificationRevision::R3_X);
         SinkProtocolLayer::new(driver, header)
     }
 
     /// Create a new sink policy engine with a given `driver`.
-    pub fn new(driver: &'a mut DRIVER, device_policy_manager: &'a mut DPM) -> Self {
+    pub fn new(driver: DRIVER, device_policy_manager: DPM) -> Self {
         Self {
             device_policy_manager,
             protocol_layer: Self::new_protocol_layer(driver),
@@ -206,7 +206,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
     }
 
     /// Create a new dual role sink policy engine with a given `driver`.
-    pub fn new_dual_role(driver: &'a mut DRIVER, device_policy_manager: &'a mut DPM) -> Self {
+    pub fn new_dual_role(driver: DRIVER, device_policy_manager: DPM) -> Self {
         Self {
             device_policy_manager,
             protocol_layer: Self::new_protocol_layer(driver),
@@ -223,8 +223,13 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
     }
 
     /// Set a new driver when re-attached.
-    pub fn re_attach(&mut self, driver: &'a mut DRIVER) {
+    pub fn re_attach(&mut self, driver: DRIVER) {
         self.protocol_layer = Self::new_protocol_layer(driver);
+    }
+
+    /// Consume the policy engine and return the inner PHY driver and DPM
+    pub fn deconstruct(self) -> (DRIVER, DPM) {
+        (self.protocol_layer.deconstruct(), self.device_policy_manager)
     }
 
     /// Run a single step in the policy engine state machine.
@@ -320,7 +325,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
             let step_result = self.run_step().await?;
 
             if let PolicyEngineResult::Exit(run_result) = step_result {
-                return Ok(run_result)
+                return Ok(run_result);
             }
         }
     }
@@ -335,7 +340,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
     /// Per spec section 6.4.1.2.2, after a Soft Reset while in EPR Mode, the source sends
     /// EPR_Source_Capabilities. Therefore this function must handle both message types.
     async fn wait_for_source_capabilities(
-        protocol_layer: &mut SinkProtocolLayer<'a, DRIVER, TIMER>,
+        protocol_layer: &mut SinkProtocolLayer<DRIVER, TIMER>,
     ) -> Result<SourceCapabilities, Error> {
         let message = protocol_layer.wait_for_source_capabilities().await?;
         trace!("Source capabilities: {:?}", message);

--- a/usbpd/src/sink/policy_engine/mod.rs
+++ b/usbpd/src/sink/policy_engine/mod.rs
@@ -952,6 +952,15 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<DRIVER, TIMER, DPM> {
             // 8.3.3.19.4.8 (PE_PRS_SNK_SRC_Reject_Swap):
             PowerRoleSwap::Reject => {
                 // FIXME: Wait Message logic
+                /*
+                   There is also the option to exit this state with a Wait message if the DPM decides
+                   that the swap request can be met in the future. Adding the ability for the DPM to
+                   return Waits to these types of message would be a good feature to implement in the
+                   future, but is not necessary.
+
+                   For example, a workaround to this would be if the DPM wants to respond Wait, but can't,
+                   the DPM can itself request a Swap once it can fulfill the requirements.
+                */
                 self.protocol_layer
                     .transmit_control_message(ControlMessageType::Reject)
                     .await?;

--- a/usbpd/src/sink/policy_engine/mod.rs
+++ b/usbpd/src/sink/policy_engine/mod.rs
@@ -105,6 +105,7 @@ enum PowerRoleSwap {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum FastPowerRoleSwap {
     // TODO: Determine how to best poll & enter FrSwaps
+    #[allow(unused)]
     Start,
     Send,
     TransitionToOff,

--- a/usbpd/src/sink/policy_engine/mod.rs
+++ b/usbpd/src/sink/policy_engine/mod.rs
@@ -18,7 +18,7 @@ use crate::protocol_layer::message::header::{
 use crate::protocol_layer::message::{Payload, extended};
 use crate::protocol_layer::{ProtocolError, RxError, SinkProtocolLayer, TxError};
 use crate::timers::{Timer, TimerType};
-use crate::{Contract, DataRole, PowerRole, SwapType, units};
+use crate::{Contract, DataRole, PolicyEngineResult, PowerRole, RunResult, SwapType, units};
 
 #[cfg(test)]
 mod tests;
@@ -171,8 +171,6 @@ pub enum Error {
     PortPartnerUnresponsive,
     /// Entered ErrorRecovery mode. This requests a disconnect.
     ReconnectionRequired,
-    /// FIXME: Easiest way to signal to device to swap to source
-    SwapToSource,
     /// A protocol error has occured.
     Protocol(ProtocolError),
 }
@@ -230,11 +228,8 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
     }
 
     /// Run a single step in the policy engine state machine.
-    async fn run_step(&mut self) -> Result<(), Error> {
+    async fn run_step(&mut self) -> Result<PolicyEngineResult, Error> {
         let result = self.update_state().await;
-        if result.is_ok() {
-            return Ok(());
-        }
 
         if let Err(Error::Protocol(protocol_error)) = result {
             let new_state = match (&self.mode, &self.state, protocol_error) {
@@ -310,7 +305,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                 self.state = state
             }
 
-            Ok(())
+            Ok(PolicyEngineResult::Continue)
         } else {
             error!("Unrecoverable result {:?} in sink state transition", result);
             result
@@ -320,9 +315,13 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
     /// Run the sink's state machine continuously.
     ///
     /// The loop is only broken for unrecoverable errors, for example if the port partner is unresponsive.
-    pub async fn run(&mut self) -> Result<(), Error> {
+    pub async fn run(&mut self) -> Result<RunResult, Error> {
         loop {
-            self.run_step().await?;
+            let step_result = self.run_step().await?;
+
+            if let PolicyEngineResult::Exit(run_result) = step_result {
+                return Ok(run_result)
+            }
         }
     }
 
@@ -350,7 +349,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
         Ok(capabilities)
     }
 
-    async fn update_state(&mut self) -> Result<(), Error> {
+    async fn update_state(&mut self) -> Result<PolicyEngineResult, Error> {
         let new_state = match &self.state {
             State::Startup => {
                 self.contract = Default::default();
@@ -737,7 +736,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                         // Inform DPM of timeout (no capabilities received)
                         warn!("Get_Source_Cap timeout, returning to Ready");
                         self.state = State::Ready(false);
-                        return Ok(());
+                        return Ok(PolicyEngineResult::Continue);
                     }
                     Err(e) => return Err(e.into()),
                 };
@@ -789,9 +788,9 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
             // 8.3.3.26.2/4 Sink EPR Mode Entry/Exit, 8.3.3.3.3, 8.3.3.3.11
             State::EprMode(epr_state) => self.execute_epr_state(*epr_state).await?,
 
+            // Custom State - Exit sink running and signal to program to begin Source
             State::PrSwapToSourceStartup => {
-                // FIXME: Better way to transition to Source?
-                Err(Error::SwapToSource)?
+                return Ok(PolicyEngineResult::Exit(RunResult::SwapToSource));
             }
 
             // 8.3.3.28.1
@@ -803,7 +802,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
 
         self.state = new_state;
 
-        Ok(())
+        Ok(PolicyEngineResult::Continue)
     }
 
     async fn execute_data_role_swap_state(&mut self, state: DataRoleSwap) -> Result<State, Error> {
@@ -1043,7 +1042,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                     MessageType::Control(ControlMessageType::Wait) => State::Ready(false), // FIXME: inform DPM and change to `true`
                     // May also transition to ForceVconn if NotSupported message and port presently not vconn source
                     MessageType::Control(ControlMessageType::NotSupported) => State::NotSupportedReceived,
-                    _ => unreachable!(),
+                    _ => Err(Error::Protocol(ProtocolError::UnexpectedMessage))?,
                 }
             }
             // 8.3.3.20.2 (PE_VCS_Evaluate_Swap):

--- a/usbpd/src/sink/policy_engine/mod.rs
+++ b/usbpd/src/sink/policy_engine/mod.rs
@@ -127,7 +127,7 @@ enum VcsState {
     SendPsRdy,
     // FIXME: For now, forcing a different state traversla, resulting in this being unused
     #[allow(unused)]
-    ForceVconn
+    ForceVconn,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -278,7 +278,9 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                     ProtocolError::RxError(RxError::ReceiveTimeout),
                 ) => Some(State::Ready(false)),
 
-                (_, State::VconnSwap(VcsState::SendSwap), ProtocolError::RxError(RxError::ReceiveTimeout)) => Some(State::Ready(false)),
+                (_, State::VconnSwap(VcsState::SendSwap), ProtocolError::RxError(RxError::ReceiveTimeout)) => {
+                    Some(State::Ready(false))
+                }
 
                 // Unexpected messages indicate a protocol error and demand a soft reset.
                 // Per spec 6.8.1 Table 6.72 (for non-power-transitioning states).
@@ -444,9 +446,8 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                 let event_fut = self
                     .device_policy_manager
                     .get_event(self.source_capabilities.as_ref().unwrap());
-                let power_source = match self.contract {
-                    Contract::Explicit(p) => p,
-                    _ => unreachable!(),
+                let Contract::Explicit(power_source) = self.contract else {
+                    unreachable!();
                 };
                 let pps_periodic_fut = async {
                     match power_source {
@@ -525,7 +526,9 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                             },
                             // Per spec 8.3.3.3.7: Get_Sink_Cap → GiveSinkCap (send Sink_Capabilities)
                             MessageType::Control(ControlMessageType::GetSinkCap) => State::GiveSinkCap(Mode::Spr),
-                            MessageType::Control(ControlMessageType::VconnSwap) => State::VconnSwap(VcsState::EvaluateSwap),
+                            MessageType::Control(ControlMessageType::VconnSwap) => {
+                                State::VconnSwap(VcsState::EvaluateSwap)
+                            }
                             // Per spec 8.3.3.3.7: EPR_Get_Sink_Cap → GiveSinkCap (send EPR_Sink_Capabilities)
                             MessageType::Extended(ExtendedMessageType::ExtendedControl) => {
                                 if let Some(Payload::Extended(extended::Extended::ExtendedControl(ctrl))) =
@@ -551,10 +554,13 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                         Event::ExitEprMode => State::EprMode(EprState::SendExit),
                         Event::RequestPower(power_source) => State::SelectCapability(power_source),
                         Event::RequestVconnSwap => State::VconnSwap(VcsState::SendSwap),
-                        Event::FastPowerRoleSwap => match self.dual_role {
-                            true => State::DrpSwap(SwapState::FastPower(FastPowerRoleSwap::Send)),
-                            false => State::ErrorRecovery,
-                        },
+                        Event::FastPowerRoleSwap => {
+                            if self.dual_role {
+                                State::DrpSwap(SwapState::FastPower(FastPowerRoleSwap::Send))
+                            } else {
+                                State::ErrorRecovery
+                            }
+                        }
                         Event::RequestPowerRoleSwap => State::DrpSwap(SwapState::Power(PowerRoleSwap::Send)),
                         Event::RequestDataRoleSwap => State::DrpSwap(SwapState::Data(DataRoleSwap::Send)),
                         Event::None => State::Ready(false),
@@ -578,10 +584,11 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                 State::Ready(false)
             }
             State::NotSupportedReceived => {
-                // FIXME: This unwrap scares me
-                self.device_policy_manager
-                    .inform(&self.source_capabilities.clone().unwrap(), Info::None)
-                    .await;
+                let Some(source_caps) = self.source_capabilities.clone() else {
+                    return Err(Error::Protocol(ProtocolError::UnexpectedMessage));
+                };
+
+                self.device_policy_manager.inform(&source_caps, Info::None).await;
                 State::Ready(false)
             }
             State::SendSoftReset => {
@@ -776,14 +783,10 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
             },
 
             // 8.3.3.20 Sink Vconn Swap
-            State::VconnSwap(vcs_state) => {
-                self.execute_vconn_swap_state(*vcs_state).await?
-            }
+            State::VconnSwap(vcs_state) => self.execute_vconn_swap_state(*vcs_state).await?,
 
             // 8.3.3.26.2/4 Sink EPR Mode Entry/Exit, 8.3.3.3.3, 8.3.3.3.11
-            State::EprMode(epr_state) => {
-                self.execute_epr_state(*epr_state).await?
-            }
+            State::EprMode(epr_state) => self.execute_epr_state(*epr_state).await?,
 
             State::PrSwapToSourceStartup => {
                 // FIXME: Better way to transition to Source?
@@ -805,10 +808,12 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
     async fn execute_data_role_swap_state(&mut self, state: DataRoleSwap) -> Result<State, Error> {
         match state {
             // 8.3.3.19.2.1 (PE_DRS_DFP_UFP_Evaluate_Swap, PE_DRS_UFP_DFP_Evaluate_Swap):
-            DataRoleSwap::Evaluate => match self.device_policy_manager.evaluate_swap_request(SwapType::Data).await {
-                true => Ok(State::DrpSwap(SwapState::Data(DataRoleSwap::Accept))),
-                false => Ok(State::DrpSwap(SwapState::Data(DataRoleSwap::Reject))),
-            },
+            DataRoleSwap::Evaluate => Ok(State::DrpSwap(SwapState::Data(
+                match self.device_policy_manager.evaluate_swap_request(SwapType::Data).await {
+                    true => DataRoleSwap::Accept,
+                    false => DataRoleSwap::Reject,
+                },
+            ))),
             // 8.3.3.19.1.3 (PE_DRS_DFP_UFP_Accept_Swap, PE_DRS_UFP_DFP_Accept_Swap):
             DataRoleSwap::Accept => {
                 self.protocol_layer
@@ -818,7 +823,10 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
             }
             // 8.3.3.19.1.4 (PE_DRS_DFP_UFP_Change_to_UFP_Swap, PE_DRS_UFP_DFP_Change_to_DFP_Swap):
             DataRoleSwap::Change => {
-                let new_role = DataRole::from(!bool::from(self.protocol_layer.header().port_data_role()));
+                let new_role = match self.protocol_layer.header().port_data_role() {
+                    DataRole::Ufp => DataRole::Dfp,
+                    DataRole::Dfp => DataRole::Ufp,
+                };
                 self.device_policy_manager.swap_data_role(new_role).await;
                 Ok(State::Ready(false))
             }
@@ -865,10 +873,13 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
     async fn execute_power_role_swap_state(&mut self, state: PowerRoleSwap) -> Result<State, Error> {
         match state {
             // 8.3.3.19.4.2 (PE_PRS_SNK_SRC_Evaluate_Swap):
-            PowerRoleSwap::Evaluate => match self.device_policy_manager.evaluate_swap_request(SwapType::Power).await {
-                true => Ok(State::DrpSwap(SwapState::Power(PowerRoleSwap::Accept))),
-                false => Ok(State::DrpSwap(SwapState::Power(PowerRoleSwap::Reject))),
-            },
+            PowerRoleSwap::Evaluate => {
+                if self.device_policy_manager.evaluate_swap_request(SwapType::Power).await {
+                    Ok(State::DrpSwap(SwapState::Power(PowerRoleSwap::Accept)))
+                } else {
+                    Ok(State::DrpSwap(SwapState::Power(PowerRoleSwap::Reject)))
+                }
+            }
             // 8.3.3.19.4.3 (PE_PRS_SNK_SRC_Accept_Swap):
             PowerRoleSwap::Accept => {
                 self.protocol_layer
@@ -1055,7 +1066,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                 } else {
                     State::VconnSwap(VcsState::TurnOnVconn)
                 }
-            },
+            }
             // 8.3.3.20.4 (PE_VCS_Reject_Swap):
             VcsState::RejectSwap => {
                 // FIXME: Wait Message logic
@@ -1064,7 +1075,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                     .await?;
 
                 State::Ready(false)
-            },
+            }
             // 8.3.3.20.5 (PE_VCS_Wait_for_Vconn):
             VcsState::WaitForVconn => {
                 self.protocol_layer
@@ -1072,7 +1083,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                     .await?;
 
                 State::VconnSwap(VcsState::TurnOffVconn)
-            },
+            }
             // 8.3.3.20.6 (PE_VCS_Turn_Off_Vconn):
             VcsState::TurnOffVconn => {
                 self.device_policy_manager
@@ -1081,7 +1092,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                     .map_err(|_| Error::ReconnectionRequired)?;
 
                 State::Ready(false)
-            },
+            }
             // 8.3.3.20.7 (PE_VCS_Turn_On_Vconn):
             VcsState::TurnOnVconn => {
                 self.device_policy_manager
@@ -1089,14 +1100,14 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                     .await
                     .map_err(|_| Error::ReconnectionRequired)?;
                 State::VconnSwap(VcsState::SendPsRdy)
-            },
+            }
             // 8.3.3.20.8 (PE_VCS_Send_PS_Rdy):
             VcsState::SendPsRdy => {
                 self.protocol_layer
                     .transmit_control_message(ControlMessageType::PsRdy)
                     .await?;
                 State::Ready(false)
-            },
+            }
             // 8.3.3.20.9 (PE_VCS_Force_Vconn):
             VcsState::ForceVconn => {
                 self.device_policy_manager
@@ -1104,7 +1115,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                     .await
                     .map_err(|_| Error::ReconnectionRequired)?;
                 State::Ready(false)
-            },
+            }
         };
 
         Ok(new_state)
@@ -1216,14 +1227,14 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                         State::HardReset
                     }
                 }
-            },
+            }
             // 8.3.3.26.4.1 (PE_SNK_Send_EPR_Mode_Exit):
             EprState::SendExit => {
                 // Inform partner we are exiting EPR.
                 self.protocol_layer.transmit_epr_mode(Action::Exit, 0).await?;
                 self.mode = Mode::Spr;
                 State::WaitForCapabilities
-            },
+            }
             // 8.3.3.26.4.2 (PE_SNK_EPR_Mode_Exit_Received):
             EprState::ExitReceived => {
                 // Per USB PD Spec R3.2 Section 8.3.3.26.4.2 (PE_SNK_EPR_Mode_Exit_Received):
@@ -1247,7 +1258,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                 } else {
                     State::WaitForCapabilities
                 }
-            },
+            }
             // 8.3.3.3.11 (PE_SNK_EPR_Keep_Alive):
             EprState::KeepAlive => {
                 // - Entry: Send EPR_KeepAlive message, start SenderResponseTimer
@@ -1282,7 +1293,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SinkDpm> Sink<'a, DRIVER, TIMER, DPM
                     }
                     Err(_) => State::HardReset,
                 }
-            },
+            }
         };
 
         Ok(new_state)

--- a/usbpd/src/sink/policy_engine/tests.rs
+++ b/usbpd/src/sink/policy_engine/tests.rs
@@ -11,14 +11,11 @@ use crate::protocol_layer::message::header::{
     ControlMessageType, DataMessageType, ExtendedMessageType, Header, MessageType,
 };
 use crate::protocol_layer::message::{Message, Payload};
+use crate::sink::device_policy_manager::SinkDpm;
 use crate::sink::policy_engine::State;
 
-fn get_policy_engine() -> Sink<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DummySinkDevice> {
-    Sink::new(DummyDriver::new(), DummySinkDevice {})
-}
-
-fn simulate_source_control_message<DPM: crate::sink::device_policy_manager::DevicePolicyManager>(
-    policy_engine: &mut Sink<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+fn simulate_source_control_message<DPM: SinkDpm>(
+    policy_engine: &mut Sink<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
     control_message_type: ControlMessageType,
     message_id: u8,
 ) {
@@ -46,8 +43,8 @@ fn get_source_header_template() -> Header {
 
 /// Simulate an EPR Mode data message from the source with proper API.
 /// Returns the serialized bytes for assertion.
-fn simulate_source_epr_mode_message<DPM: crate::sink::device_policy_manager::DevicePolicyManager>(
-    policy_engine: &mut Sink<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+fn simulate_source_epr_mode_message<DPM: SinkDpm>(
+    policy_engine: &mut Sink<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
     action: Action,
     message_id: u8,
 ) -> heapless::Vec<u8, MAX_DATA_MESSAGE_SIZE> {
@@ -75,8 +72,8 @@ fn simulate_source_epr_mode_message<DPM: crate::sink::device_policy_manager::Dev
 
 /// Simulate an EprKeepAliveAck extended control message from the source.
 /// Returns the serialized bytes for assertion.
-fn simulate_epr_keep_alive_ack<DPM: crate::sink::device_policy_manager::DevicePolicyManager>(
-    policy_engine: &mut Sink<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+fn simulate_epr_keep_alive_ack<DPM: SinkDpm>(
+    policy_engine: &mut Sink<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
     message_id: u8,
 ) -> heapless::Vec<u8, MAX_DATA_MESSAGE_SIZE> {
     use crate::protocol_layer::message::Payload;
@@ -111,7 +108,9 @@ fn simulate_epr_keep_alive_ack<DPM: crate::sink::device_policy_manager::DevicePo
 #[tokio::test]
 async fn test_negotiation() {
     // Instantiated in `Discovery` state
-    let mut policy_engine = get_policy_engine();
+    let mut driver = DummyDriver::new();
+    let mut device = DummySinkDevice {};
+    let mut policy_engine = Sink::new(&mut driver, &mut device);
 
     // Provide capabilities
     policy_engine
@@ -169,8 +168,10 @@ async fn test_epr_negotiation() {
     use crate::dummy::{DUMMY_SPR_CAPS_EPR_CAPABLE, DummySinkEprDevice};
 
     // Create policy engine with EPR-capable DPM
+    let mut driver = DummyDriver::new();
+    let mut device = DummySinkEprDevice::new();
     let mut policy_engine: Sink<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DummySinkEprDevice> =
-        Sink::new(DummyDriver::new(), DummySinkEprDevice::new());
+        Sink::new(&mut driver, &mut device);
 
     // === Phase 1: Initial SPR Negotiation ===
     // Using same flow as test_negotiation
@@ -506,8 +507,8 @@ async fn test_epr_negotiation() {
         eprintln!("--- Keep-Alive cycle {} ---", cycle);
 
         // Manually set state to EprKeepAlive (normally triggered by SinkEPRKeepAliveTimer in Ready state)
-        if let State::Ready(power_source, _) = policy_engine.state.clone() {
-            policy_engine.state = State::EprKeepAlive(power_source);
+        if let State::Ready(_) = policy_engine.state.clone() {
+            policy_engine.state = State::EprMode(crate::sink::policy_engine::EprState::KeepAlive);
         } else {
             panic!("Expected Ready state before keep-alive cycle {}", cycle);
         }

--- a/usbpd/src/sink/policy_engine/tests.rs
+++ b/usbpd/src/sink/policy_engine/tests.rs
@@ -15,7 +15,7 @@ use crate::sink::device_policy_manager::SinkDpm;
 use crate::sink::policy_engine::State;
 
 fn simulate_source_control_message<DPM: SinkDpm>(
-    policy_engine: &mut Sink<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+    policy_engine: &mut Sink<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
     control_message_type: ControlMessageType,
     message_id: u8,
 ) {
@@ -44,7 +44,7 @@ fn get_source_header_template() -> Header {
 /// Simulate an EPR Mode data message from the source with proper API.
 /// Returns the serialized bytes for assertion.
 fn simulate_source_epr_mode_message<DPM: SinkDpm>(
-    policy_engine: &mut Sink<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+    policy_engine: &mut Sink<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
     action: Action,
     message_id: u8,
 ) -> heapless::Vec<u8, MAX_DATA_MESSAGE_SIZE> {
@@ -73,7 +73,7 @@ fn simulate_source_epr_mode_message<DPM: SinkDpm>(
 /// Simulate an EprKeepAliveAck extended control message from the source.
 /// Returns the serialized bytes for assertion.
 fn simulate_epr_keep_alive_ack<DPM: SinkDpm>(
-    policy_engine: &mut Sink<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+    policy_engine: &mut Sink<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
     message_id: u8,
 ) -> heapless::Vec<u8, MAX_DATA_MESSAGE_SIZE> {
     use crate::protocol_layer::message::Payload;
@@ -108,9 +108,9 @@ fn simulate_epr_keep_alive_ack<DPM: SinkDpm>(
 #[tokio::test]
 async fn test_negotiation() {
     // Instantiated in `Discovery` state
-    let mut driver = DummyDriver::new();
-    let mut device = DummySinkDevice {};
-    let mut policy_engine = Sink::new(&mut driver, &mut device);
+    let driver = DummyDriver::new();
+    let device = DummySinkDevice {};
+    let mut policy_engine = Sink::new(driver, device);
 
     // Provide capabilities
     policy_engine
@@ -168,10 +168,10 @@ async fn test_epr_negotiation() {
     use crate::dummy::{DUMMY_SPR_CAPS_EPR_CAPABLE, DummySinkEprDevice};
 
     // Create policy engine with EPR-capable DPM
-    let mut driver = DummyDriver::new();
-    let mut device = DummySinkEprDevice::new();
-    let mut policy_engine: Sink<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DummySinkEprDevice> =
-        Sink::new(&mut driver, &mut device);
+    let driver = DummyDriver::new();
+    let device = DummySinkEprDevice::new();
+    let mut policy_engine =
+        Sink::<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DummySinkEprDevice>::new(driver, device);
 
     // === Phase 1: Initial SPR Negotiation ===
     // Using same flow as test_negotiation

--- a/usbpd/src/source/device_policy_manager.rs
+++ b/usbpd/src/source/device_policy_manager.rs
@@ -4,10 +4,10 @@
 //! or renegotiate the power contract.
 use core::future::Future;
 
-use crate::DataRole;
 use crate::protocol_layer::message::data::request;
 use crate::protocol_layer::message::data::sink_capabilities::SinkCapabilities;
 use crate::protocol_layer::message::data::source_capabilities::SourceCapabilities;
+use crate::{DataRole, SwapType};
 
 /// Events that the device policy manager can send to the policy engine.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -35,6 +35,8 @@ pub enum Event {
 #[derive(Debug)]
 /// Information that the policy engine will publish to the DPM
 pub enum Info {
+    /// Request is not supported by the Sink
+    NotSupportedReceived,
     /// SPR Sink Capabilities
     SprSinkCapabilities(Option<SinkCapabilities>),
     /// EPR Sink Capabilities
@@ -55,20 +57,10 @@ pub enum CapabilityResponse {
     Accept,
 }
 
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-/// For defining DPM swap behavior
-pub enum SwapType {
-    /// **DRP** Data Role Swap (UFP <---> DFP)
-    Data,
-    /// **DRP** Power Role Swap (Source --> Sink)
-    Power,
-}
-
 // FIXME: Use trait aliasing once stable: https://github.com/rust-lang/rust/issues/41517
 /// Full implementation for the source device policy manager.
 /// The default implementations of the traits will handle the case where a feature is unsupported.
-pub trait SourceDpm: DevicePolicyManager + EprDevicePolicyManager + DualRoleDevicePolicyManager {}
+pub trait SourceDpm: DevicePolicyManager + EprDevicePolicyManager + DrpDevicePolicyManager {}
 
 /// Trait for the device policy manager.
 ///
@@ -134,9 +126,9 @@ pub trait DevicePolicyManager {
     }
 }
 
-/// **EPR** Extended Power Range mode device implementation
+/// **EPR** Extended Power Range Source device implementation
 ///
-/// Leave unimplemented if EPR is not supported by the device.
+/// Leave blank if EPR is not supported by the device.
 pub trait EprDevicePolicyManager {
     /// **EPR** Return `true` if device is EPR capable.
     ///
@@ -156,10 +148,10 @@ pub trait EprDevicePolicyManager {
     }
 }
 
-/// **DRP** Dual Role Port device implementations
+/// **DRP** Dual Role Port Source device implementations
 ///
-/// Leave unimplemented if the device is not a DRP.
-pub trait DualRoleDevicePolicyManager {
+/// Leave blank if the device is not a DRP.
+pub trait DrpDevicePolicyManager {
     /// **DRP** Respond to the Policy Engine's request for this port's current sink capabilities
     ///
     /// Defaults to only default usb capability (5v @ 500 mA)
@@ -167,8 +159,7 @@ pub trait DualRoleDevicePolicyManager {
         async { SinkCapabilities::new_vsafe5v_only(3 * 100) }
     }
 
-    /// Evaluate a swap request:
-    /// - **DRP**: Data, Power, Fast Power
+    /// **DRP** Evaluate a swap request
     fn evaluate_swap_request(&mut self, _swap_request: SwapType) -> impl Future<Output = bool> {
         async { false }
     }
@@ -192,7 +183,7 @@ pub trait DualRoleDevicePolicyManager {
     /// **DRP** Turn the Source off.
     ///
     /// This will be requested before a Role Swap to Sink
-    fn disable_source(&mut self) -> impl Future<Output = ()> {
+    fn disable(&mut self) -> impl Future<Output = ()> {
         async {}
     }
 

--- a/usbpd/src/source/policy_engine/mod.rs
+++ b/usbpd/src/source/policy_engine/mod.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 use embassy_futures::select::{Either, Either3, select, select3};
 use usbpd_traits::Driver;
 
-use super::device_policy_manager::{CapabilityResponse, Event, Info, SourceDpm, SwapType};
+use super::device_policy_manager::{CapabilityResponse, Event, Info, SourceDpm};
 use crate::counters::Counter;
 use crate::protocol_layer::message::data::request::PowerSource;
 use crate::protocol_layer::message::data::sink_capabilities::SinkCapabilities;
@@ -18,7 +18,7 @@ use crate::protocol_layer::message::header::{
 use crate::protocol_layer::message::{Message, Payload};
 use crate::protocol_layer::{ProtocolError, RxError, SourceProtocolLayer, TxError};
 use crate::timers::{Timer, TimerType};
-use crate::{DataRole, PowerRole};
+use crate::{Contract, DataRole, PowerRole, SwapType};
 
 #[cfg(test)]
 mod tests;
@@ -34,24 +34,13 @@ enum Mode {
     Epr,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
-enum Contract {
-    #[default]
-    Safe5V,
-    Implicit, // Only present after fast role swap. Limited to max. type C current.
-    TransitionToExplicit,
-    Explicit(PowerSource),
-
-    // Source EPR support may use this enum
-    _Invalid,
-}
-
 /// Source states.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum State {
     // States of the policy engine as given by specification.
     // 8.3.3.2 Policy Engine Source Port State Diagram
+    /// Default state at startup.
     Startup { role_swap: bool },
     Discovery,
     SendCapabilities,
@@ -67,21 +56,21 @@ enum State {
     WaitNewCapabilities,
     EprKeepAlive,
     GiveSourceCap,
-    // 8.3.3.4 Source Port Soft Reset
+    /// 8.3.3.4 Source Port Soft Reset
     SendSoftReset,
     SoftReset,
-    // 8.3.3.6 Not Supported Message State
+    /// 8.3.3.6 Not Supported Message State
     SendNotSupported,
     NotSupportedReceived,
-    // 8.3.3.19 Dual-Role Port (DRP) States
+    /// 8.3.3.19 Dual-Role Port (DRP) States
     DrpSwap(SwapState),
     DrpGetSourceCap(Mode),
     DrpGiveSinkCap(Mode),
-    // 8.3.3.20 Vconn Swap
+    /// 8.3.3.20 Vconn Swap
     VconnSwap { source: VcsSwapSource, state: VcsState },
-    // 8.3.3.26 EPR States
+    /// 8.3.3.26 EPR States
     EprMode(EprState),
-    // Custom state to signal exit out of source to sink from a power swap
+    /// Custom state to signal exit out of source to sink from a power swap
     PrSwapToSinkStartup,
     ErrorRecovery,
 }
@@ -169,9 +158,9 @@ enum EprState {
 /// Implementation of the source policy engine.
 /// See spec, [8.3.3.2]
 #[derive(Debug)]
-pub struct Source<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> {
-    device_policy_manager: DPM,
-    protocol_layer: SourceProtocolLayer<DRIVER, TIMER>,
+pub struct Source<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> {
+    device_policy_manager: &'a mut DPM,
+    protocol_layer: SourceProtocolLayer<'a, DRIVER, TIMER>,
     hard_reset_counter: Counter,
     caps_counter: Counter,
     state: State,
@@ -192,7 +181,7 @@ pub enum Error {
     PortPartnerUnresponsive,
     /// Entered ErrorRecovery mode. This requests a disconnect.
     ReconnectionRequired,
-    /// Easiest way to signal to device to swap to sink
+    /// FIXME: Easiest way to signal to device to swap to sink
     SwapToSink,
     /// A protocol error has occured.
     Protocol(ProtocolError),
@@ -204,14 +193,14 @@ impl From<ProtocolError> for Error {
     }
 }
 
-impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
-    fn new_protocol_layer(driver: DRIVER) -> SourceProtocolLayer<DRIVER, TIMER> {
+impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<'a, DRIVER, TIMER, DPM> {
+    fn new_protocol_layer(driver: &'a mut DRIVER) -> SourceProtocolLayer<'a, DRIVER, TIMER> {
         let header = Header::new_template(DataRole::Dfp, PowerRole::Source, SpecificationRevision::R3_X);
         SourceProtocolLayer::new(driver, header)
     }
 
-    /// Create a new source policy engine with a given `driver` that implements SourceDPM.
-    pub fn new(driver: DRIVER, device_policy_manager: DPM, role_swap: bool) -> Self {
+    /// Create a new source policy engine with a given `driver` and device policy manager (DPM).
+    pub fn new(driver: &'a mut DRIVER, device_policy_manager: &'a mut DPM, role_swap: bool) -> Self {
         Self {
             device_policy_manager,
             protocol_layer: Self::new_protocol_layer(driver),
@@ -229,17 +218,16 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
     }
 
     /// Create a new source policy engine with dual role capabilities,
-    /// with a given `driver` that implements both SourceDPM and SinkDPM (at least to some extent).
-    pub fn new_dual_role(driver: DRIVER, device_policy_manager: DPM, role_swapped: bool) -> Self {
+    /// with a given `driver` and device policy manager (DPM).
+    pub fn new_dual_role(driver: &'a mut DRIVER, device_policy_manager: &'a mut DPM, role_swapped: bool) -> Self {
         Self {
             device_policy_manager,
             protocol_layer: Self::new_protocol_layer(driver),
             hard_reset_counter: Counter::new(crate::counters::CounterType::HardReset),
             caps_counter: Counter::new(crate::counters::CounterType::Caps),
 
-            state: match role_swapped {
-                true => State::SendCapabilities,
-                false => State::Startup { role_swap: false },
+            state: State::Startup {
+                role_swap: role_swapped,
             },
             contract: match role_swapped {
                 true => Contract::Implicit,
@@ -254,7 +242,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
     }
 
     /// Set a new driver when re-attached.
-    pub fn re_attach(&mut self, driver: DRIVER) {
+    pub fn re_attach(&mut self, driver: &'a mut DRIVER) {
         self.protocol_layer = Self::new_protocol_layer(driver);
     }
 
@@ -351,13 +339,12 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
         let new_state = match &self.state {
             // 8.3.3.2.1 (PE_SR_Startup):
             State::Startup { role_swap } => {
-                self.contract = Default::default();
+                self.contract = Default::default(); // FIXME: How to use Contract::Implicit?
                 self.mode = Default::default();
                 self.protocol_layer.reset();
                 self.caps_counter.reset();
 
                 if *role_swap {
-                    self.contract = Contract::Implicit;
                     TimerType::get_timer::<TIMER>(TimerType::SwapSourceStart).await;
                 }
 
@@ -756,7 +743,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
             }
             // 8.3.3.6.1.2 (PE_SRC_Not_Supported_Received):
             State::NotSupportedReceived => {
-                // FIXME: Entry: Inform the Device Policy Manager
+                self.device_policy_manager.inform(Info::NotSupportedReceived).await;
                 State::Ready
             }
 
@@ -904,7 +891,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
             }
             // 8.3.3.19.3.4 (PE_PRS_SRC_SNK_Transition_to_off):
             PowerRoleSwap::TransitionToOff => {
-                self.device_policy_manager.disable_source().await;
+                self.device_policy_manager.disable().await;
                 Ok(State::DrpSwap(SwapState::Power(PowerRoleSwap::AssertRd)))
             }
             // 8.3.3.19.3.5 (PE_PRS_SRC_SNK_Assert_Rd):

--- a/usbpd/src/source/policy_engine/mod.rs
+++ b/usbpd/src/source/policy_engine/mod.rs
@@ -163,9 +163,9 @@ enum EprState {
 /// Implementation of the source policy engine.
 /// See spec, [8.3.3.2]
 #[derive(Debug)]
-pub struct Source<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> {
-    device_policy_manager: &'a mut DPM,
-    protocol_layer: SourceProtocolLayer<'a, DRIVER, TIMER>,
+pub struct Source<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> {
+    device_policy_manager: DPM,
+    protocol_layer: SourceProtocolLayer<DRIVER, TIMER>,
     hard_reset_counter: Counter,
     caps_counter: Counter,
     state: State,
@@ -196,14 +196,14 @@ impl From<ProtocolError> for Error {
     }
 }
 
-impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<'a, DRIVER, TIMER, DPM> {
-    fn new_protocol_layer(driver: &'a mut DRIVER) -> SourceProtocolLayer<'a, DRIVER, TIMER> {
+impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
+    fn new_protocol_layer(driver: DRIVER) -> SourceProtocolLayer<DRIVER, TIMER> {
         let header = Header::new_template(DataRole::Dfp, PowerRole::Source, SpecificationRevision::R3_X);
         SourceProtocolLayer::new(driver, header)
     }
 
     /// Create a new source policy engine with a given `driver` and device policy manager (DPM).
-    pub fn new(driver: &'a mut DRIVER, device_policy_manager: &'a mut DPM, role_swap: bool) -> Self {
+    pub fn new(driver: DRIVER, device_policy_manager: DPM, role_swap: bool) -> Self {
         Self {
             device_policy_manager,
             protocol_layer: Self::new_protocol_layer(driver),
@@ -222,7 +222,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<'a, DRIVER, TIMER,
 
     /// Create a new source policy engine with dual role capabilities,
     /// with a given `driver` and device policy manager (DPM).
-    pub fn new_dual_role(driver: &'a mut DRIVER, device_policy_manager: &'a mut DPM, role_swapped: bool) -> Self {
+    pub fn new_dual_role(driver: DRIVER, device_policy_manager: DPM, role_swapped: bool) -> Self {
         Self {
             device_policy_manager,
             protocol_layer: Self::new_protocol_layer(driver),
@@ -244,8 +244,13 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<'a, DRIVER, TIMER,
         }
     }
 
+    /// Consume the policy engine and return the inner PHY driver and DPM
+    pub fn deconstruct(self) -> (DRIVER, DPM) {
+        (self.protocol_layer.deconstruct(), self.device_policy_manager)
+    }
+
     /// Set a new driver when re-attached.
-    pub fn re_attach(&mut self, driver: &'a mut DRIVER) {
+    pub fn re_attach(&mut self, driver: DRIVER) {
         self.protocol_layer = Self::new_protocol_layer(driver);
     }
 
@@ -336,7 +341,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<'a, DRIVER, TIMER,
             let step_result = self.run_step().await?;
 
             if let PolicyEngineResult::Exit(run_result) = step_result {
-                return Ok(run_result)
+                return Ok(run_result);
             }
         }
     }
@@ -346,7 +351,9 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<'a, DRIVER, TIMER,
         let new_state = match &self.state {
             // 8.3.3.2.1 (PE_SR_Startup):
             State::Startup { role_swap } => {
-                self.contract = Default::default(); // FIXME: How to use Contract::Implicit?
+                if !role_swap {
+                    self.contract = Contract::default();
+                }
                 self.mode = Default::default();
                 self.protocol_layer.reset();
                 self.caps_counter.reset();

--- a/usbpd/src/source/policy_engine/mod.rs
+++ b/usbpd/src/source/policy_engine/mod.rs
@@ -41,7 +41,9 @@ enum State {
     // States of the policy engine as given by specification.
     // 8.3.3.2 Policy Engine Source Port State Diagram
     /// Default state at startup.
-    Startup { role_swap: bool },
+    Startup {
+        role_swap: bool,
+    },
     Discovery,
     SendCapabilities,
     NegotiateCapability(PowerSource),
@@ -67,7 +69,10 @@ enum State {
     DrpGetSourceCap(Mode),
     DrpGiveSinkCap(Mode),
     /// 8.3.3.20 Vconn Swap
-    VconnSwap { source: VcsSwapSource, state: VcsState },
+    VconnSwap {
+        source: VcsSwapSource,
+        state: VcsState,
+    },
     /// 8.3.3.26 EPR States
     EprMode(EprState),
     /// Custom state to signal exit out of source to sink from a power swap

--- a/usbpd/src/source/policy_engine/mod.rs
+++ b/usbpd/src/source/policy_engine/mod.rs
@@ -18,7 +18,7 @@ use crate::protocol_layer::message::header::{
 use crate::protocol_layer::message::{Message, Payload};
 use crate::protocol_layer::{ProtocolError, RxError, SourceProtocolLayer, TxError};
 use crate::timers::{Timer, TimerType};
-use crate::{Contract, DataRole, PowerRole, SwapType};
+use crate::{Contract, DataRole, PolicyEngineResult, PowerRole, RunResult, SwapType};
 
 #[cfg(test)]
 mod tests;
@@ -186,8 +186,6 @@ pub enum Error {
     PortPartnerUnresponsive,
     /// Entered ErrorRecovery mode. This requests a disconnect.
     ReconnectionRequired,
-    /// FIXME: Easiest way to signal to device to swap to sink
-    SwapToSink,
     /// A protocol error has occured.
     Protocol(ProtocolError),
 }
@@ -252,10 +250,10 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<'a, DRIVER, TIMER,
     }
 
     /// Run a single step in the policy engine state machine.
-    async fn run_step(&mut self) -> Result<(), Error> {
+    async fn run_step(&mut self) -> Result<PolicyEngineResult, Error> {
         let result = self.update_state().await;
         if result.is_ok() {
-            return Ok(());
+            return Ok(PolicyEngineResult::Continue);
         }
 
         if let Err(Error::Protocol(protocol_error)) = result {
@@ -323,7 +321,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<'a, DRIVER, TIMER,
                 self.state = state
             }
 
-            Ok(())
+            Ok(PolicyEngineResult::Continue)
         } else {
             error!("Unrecoverable result {:?} in sink state transition", result);
             result
@@ -333,13 +331,17 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<'a, DRIVER, TIMER,
     /// Run the source's state machine continuously.
     ///
     /// The loop is only broken for unrecoverable errors, for example if the port partner is unresponsive.
-    pub async fn run(&mut self) -> Result<(), Error> {
+    pub async fn run(&mut self) -> Result<RunResult, Error> {
         loop {
-            self.run_step().await?;
+            let step_result = self.run_step().await?;
+
+            if let PolicyEngineResult::Exit(run_result) = step_result {
+                return Ok(run_result)
+            }
         }
     }
 
-    async fn update_state(&mut self) -> Result<(), Error> {
+    async fn update_state(&mut self) -> Result<PolicyEngineResult, Error> {
         trace!("State: {:?}", &self.state);
         let new_state = match &self.state {
             // 8.3.3.2.1 (PE_SR_Startup):
@@ -795,8 +797,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<'a, DRIVER, TIMER,
 
             // Custom State - Exit source running and signal to program to begin Sink
             State::PrSwapToSinkStartup => {
-                // FIXME: Switch to sink policy manager due to power swap
-                Err(Error::SwapToSink)?
+                return Ok(PolicyEngineResult::Exit(RunResult::SwapToSink));
             }
 
             // 8.3.3.20 Source Vconn Swap
@@ -815,7 +816,7 @@ impl<'a, DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<'a, DRIVER, TIMER,
 
         self.state = new_state;
 
-        Ok(())
+        Ok(PolicyEngineResult::Continue)
     }
 
     /// 8.3.3.19.1 DFP to UFP Data Role Swap, 8.3.3.19.2 UFP to DFP Data Role Swap

--- a/usbpd/src/source/policy_engine/tests.rs
+++ b/usbpd/src/source/policy_engine/tests.rs
@@ -3,7 +3,7 @@
 use super::Source;
 use crate::counters::{Counter, CounterType};
 use crate::dummy::{
-    DummyDriver, DummyDualRoleDevice, DummyDualRoleNoSwapsDevice, DummySourceDevice, DummyTimer, MAX_DATA_MESSAGE_SIZE,
+    DummyDriver, DummyDualRoleDevice, DummySourceDevice, DummyTimer, MAX_DATA_MESSAGE_SIZE,
     get_dummy_source_capabilities,
 };
 use crate::protocol_layer::message::Message;
@@ -12,13 +12,12 @@ use crate::protocol_layer::message::data::request::{CurrentRequest, FixedVariabl
 use crate::protocol_layer::message::data::source_capabilities::SourceCapabilities;
 use crate::protocol_layer::message::header::{ControlMessageType, DataMessageType, Header, MessageType};
 use crate::source::device_policy_manager::{
-    CapabilityResponse, DevicePolicyManager as DPM, DualRoleDevicePolicyManager as DRP_DPM,
-    EprDevicePolicyManager as EPR_DPM, SourceDpm,
+    CapabilityResponse, SourceDpm,
 };
 use crate::source::policy_engine::{DataRoleSwap, FastPowerRoleSwap, PowerRoleSwap, State, SwapState};
 
 fn simulate_sink_control_message<DPM: SourceDpm>(
-    policy_engine: &mut Source<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+    policy_engine: &mut Source<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
     control_message_type: ControlMessageType,
     message_id: u8,
 ) {
@@ -78,7 +77,7 @@ fn simulate_sink_request<DPM: SourceDpm>(
 }
 
 async fn run_test_step<DPM: SourceDpm>(
-    policy_engine: &mut Source<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+    policy_engine: &mut Source<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
     _new_state: &State,
     step_number: usize,
 ) {
@@ -94,7 +93,9 @@ async fn run_test_step<DPM: SourceDpm>(
 
 #[tokio::test]
 async fn test_negotiation() {
-    let mut policy_engine = Source::new(DummyDriver::new(), DummySourceDevice, false);
+    let mut driver = DummyDriver::new();
+    let mut device = DummySourceDevice;
+    let mut policy_engine = Source::new(&mut driver, &mut device, false);
 
     eprintln!("\n<== Starting initial source SPR negotiation test! ==>\n");
     {
@@ -252,7 +253,9 @@ async fn test_negotiation() {
 #[tokio::test]
 async fn test_discovery() {
     const MAX_DISCOVERY_ITERS: usize = 52;
-    let mut policy_engine = Source::new(DummyDriver::new(), DummySourceDevice, false);
+    let mut driver = DummyDriver::new();
+    let mut device = DummySourceDevice;
+    let mut policy_engine = Source::new(&mut driver, &mut device, false);
 
     // HardReset -> Discovery -> Disabled
     eprintln!("\n<== Starting source discovery test! ==>\n");
@@ -300,7 +303,7 @@ async fn test_discovery() {
 /// Take a new policy engine and skip the initial negotation:
 /// `Startup -> ... -> Ready`
 async fn skip_to_ready<DPM: SourceDpm>(
-    policy_engine: &mut Source<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+    policy_engine: &mut Source<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
 ) {
     assert!(matches!(policy_engine.state, State::Startup { role_swap: false }));
 
@@ -327,7 +330,9 @@ async fn skip_to_ready<DPM: SourceDpm>(
 async fn test_role_swapping() {
     eprintln!("\n<== Starting source power role swap test! ==>\n");
     {
-        let mut policy_engine = Source::new_dual_role(DummyDriver::new(), DummyDualRoleDevice, false);
+        let mut driver = DummyDriver::new();
+        let mut device = DummyDualRoleDevice;
+        let mut policy_engine = Source::new_dual_role(&mut driver, &mut device, false);
         skip_to_ready(&mut policy_engine).await;
 
         simulate_sink_control_message(&mut policy_engine, ControlMessageType::PrSwap, 2);
@@ -388,7 +393,9 @@ async fn test_role_swapping() {
 
     eprintln!("\n<== Starting source fast power role swap test! ==>\n");
     {
-        let mut policy_engine = Source::new_dual_role(DummyDriver::new(), DummyDualRoleDevice, false);
+        let mut driver = DummyDriver::new();
+        let mut device = DummyDualRoleDevice;
+        let mut policy_engine = Source::new_dual_role(&mut driver, &mut device, false);
         skip_to_ready(&mut policy_engine).await;
 
         simulate_sink_control_message(&mut policy_engine, ControlMessageType::FrSwap, 2);
@@ -448,7 +455,9 @@ async fn test_role_swapping() {
 
     eprintln!("\n<== Starting source data role swap test! ==>\n");
     {
-        let mut policy_engine = Source::new_dual_role(DummyDriver::new(), DummyDualRoleDevice, false);
+        let mut driver = DummyDriver::new();
+        let mut device = DummyDualRoleDevice;
+        let mut policy_engine = Source::new_dual_role(&mut driver, &mut device, false);
         skip_to_ready(&mut policy_engine).await;
 
         simulate_sink_control_message(&mut policy_engine, ControlMessageType::DrSwap, 2);
@@ -492,7 +501,9 @@ async fn test_role_swapping() {
     eprintln!("\n<== Starting source role swap policy engine rejects test! ==>\n");
     {
         // Test rejects at the policy engine layer (i.e. this is not a dual-role device)
-        let mut policy_engine = Source::new(DummyDriver::new(), DummyDualRoleNoSwapsDevice, false);
+        let mut driver = DummyDriver::new();
+        let mut device = DummySourceDevice;
+        let mut policy_engine = Source::new(&mut driver, &mut device, false);
         skip_to_ready(&mut policy_engine).await;
 
         simulate_sink_control_message(&mut policy_engine, ControlMessageType::PrSwap, 2);
@@ -521,8 +532,10 @@ async fn test_role_swapping() {
 
     eprintln!("\n<== Starting source role swap dpm rejects test! ==>\n");
     {
-        // Test rejects at the DPM layer (i.e. this is a dual role device that lets the DPM evaluate the requests)
-        let mut policy_engine = Source::new_dual_role(DummyDriver::new(), DummyDualRoleNoSwapsDevice, false);
+        // Test rejects at the DPM layer
+        let mut driver = DummyDriver::new();
+        let mut device = DummySourceDevice;
+        let mut policy_engine = Source::new_dual_role(&mut driver, &mut device, false);
         skip_to_ready(&mut policy_engine).await;
 
         simulate_sink_control_message(&mut policy_engine, ControlMessageType::PrSwap, 2);

--- a/usbpd/src/source/policy_engine/tests.rs
+++ b/usbpd/src/source/policy_engine/tests.rs
@@ -11,9 +11,7 @@ use crate::protocol_layer::message::data::Data;
 use crate::protocol_layer::message::data::request::{CurrentRequest, FixedVariableSupply, PowerSource, VoltageRequest};
 use crate::protocol_layer::message::data::source_capabilities::SourceCapabilities;
 use crate::protocol_layer::message::header::{ControlMessageType, DataMessageType, Header, MessageType};
-use crate::source::device_policy_manager::{
-    CapabilityResponse, SourceDpm,
-};
+use crate::source::device_policy_manager::{CapabilityResponse, SourceDpm};
 use crate::source::policy_engine::{DataRoleSwap, FastPowerRoleSwap, PowerRoleSwap, State, SwapState};
 
 fn simulate_sink_control_message<DPM: SourceDpm>(

--- a/usbpd/src/source/policy_engine/tests.rs
+++ b/usbpd/src/source/policy_engine/tests.rs
@@ -15,7 +15,7 @@ use crate::source::device_policy_manager::{CapabilityResponse, SourceDpm};
 use crate::source::policy_engine::{DataRoleSwap, FastPowerRoleSwap, PowerRoleSwap, State, SwapState};
 
 fn simulate_sink_control_message<DPM: SourceDpm>(
-    policy_engine: &mut Source<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+    policy_engine: &mut Source<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
     control_message_type: ControlMessageType,
     message_id: u8,
 ) {
@@ -75,7 +75,7 @@ fn simulate_sink_request<DPM: SourceDpm>(
 }
 
 async fn run_test_step<DPM: SourceDpm>(
-    policy_engine: &mut Source<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+    policy_engine: &mut Source<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
     _new_state: &State,
     step_number: usize,
 ) {
@@ -91,9 +91,9 @@ async fn run_test_step<DPM: SourceDpm>(
 
 #[tokio::test]
 async fn test_negotiation() {
-    let mut driver = DummyDriver::new();
-    let mut device = DummySourceDevice;
-    let mut policy_engine = Source::new(&mut driver, &mut device, false);
+    let driver = DummyDriver::new();
+    let device = DummySourceDevice;
+    let mut policy_engine = Source::new(driver, device, false);
 
     eprintln!("\n<== Starting initial source SPR negotiation test! ==>\n");
     {
@@ -251,9 +251,9 @@ async fn test_negotiation() {
 #[tokio::test]
 async fn test_discovery() {
     const MAX_DISCOVERY_ITERS: usize = 52;
-    let mut driver = DummyDriver::new();
-    let mut device = DummySourceDevice;
-    let mut policy_engine = Source::new(&mut driver, &mut device, false);
+    let driver = DummyDriver::new();
+    let device = DummySourceDevice;
+    let mut policy_engine = Source::new(driver, device, false);
 
     // HardReset -> Discovery -> Disabled
     eprintln!("\n<== Starting source discovery test! ==>\n");
@@ -301,7 +301,7 @@ async fn test_discovery() {
 /// Take a new policy engine and skip the initial negotation:
 /// `Startup -> ... -> Ready`
 async fn skip_to_ready<DPM: SourceDpm>(
-    policy_engine: &mut Source<'_, DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
+    policy_engine: &mut Source<DummyDriver<MAX_DATA_MESSAGE_SIZE>, DummyTimer, DPM>,
 ) {
     assert!(matches!(policy_engine.state, State::Startup { role_swap: false }));
 
@@ -328,9 +328,9 @@ async fn skip_to_ready<DPM: SourceDpm>(
 async fn test_role_swapping() {
     eprintln!("\n<== Starting source power role swap test! ==>\n");
     {
-        let mut driver = DummyDriver::new();
-        let mut device = DummyDualRoleDevice;
-        let mut policy_engine = Source::new_dual_role(&mut driver, &mut device, false);
+        let driver = DummyDriver::new();
+        let device = DummyDualRoleDevice;
+        let mut policy_engine = Source::new_dual_role(driver, device, false);
         skip_to_ready(&mut policy_engine).await;
 
         simulate_sink_control_message(&mut policy_engine, ControlMessageType::PrSwap, 2);
@@ -391,9 +391,9 @@ async fn test_role_swapping() {
 
     eprintln!("\n<== Starting source fast power role swap test! ==>\n");
     {
-        let mut driver = DummyDriver::new();
-        let mut device = DummyDualRoleDevice;
-        let mut policy_engine = Source::new_dual_role(&mut driver, &mut device, false);
+        let driver = DummyDriver::new();
+        let device = DummyDualRoleDevice;
+        let mut policy_engine = Source::new_dual_role(driver, device, false);
         skip_to_ready(&mut policy_engine).await;
 
         simulate_sink_control_message(&mut policy_engine, ControlMessageType::FrSwap, 2);
@@ -453,9 +453,9 @@ async fn test_role_swapping() {
 
     eprintln!("\n<== Starting source data role swap test! ==>\n");
     {
-        let mut driver = DummyDriver::new();
-        let mut device = DummyDualRoleDevice;
-        let mut policy_engine = Source::new_dual_role(&mut driver, &mut device, false);
+        let driver = DummyDriver::new();
+        let device = DummyDualRoleDevice;
+        let mut policy_engine = Source::new_dual_role(driver, device, false);
         skip_to_ready(&mut policy_engine).await;
 
         simulate_sink_control_message(&mut policy_engine, ControlMessageType::DrSwap, 2);
@@ -499,9 +499,9 @@ async fn test_role_swapping() {
     eprintln!("\n<== Starting source role swap policy engine rejects test! ==>\n");
     {
         // Test rejects at the policy engine layer (i.e. this is not a dual-role device)
-        let mut driver = DummyDriver::new();
-        let mut device = DummySourceDevice;
-        let mut policy_engine = Source::new(&mut driver, &mut device, false);
+        let driver = DummyDriver::new();
+        let device = DummySourceDevice;
+        let mut policy_engine = Source::new(driver, device, false);
         skip_to_ready(&mut policy_engine).await;
 
         simulate_sink_control_message(&mut policy_engine, ControlMessageType::PrSwap, 2);
@@ -531,9 +531,9 @@ async fn test_role_swapping() {
     eprintln!("\n<== Starting source role swap dpm rejects test! ==>\n");
     {
         // Test rejects at the DPM layer
-        let mut driver = DummyDriver::new();
-        let mut device = DummySourceDevice;
-        let mut policy_engine = Source::new_dual_role(&mut driver, &mut device, false);
+        let driver = DummyDriver::new();
+        let device = DummySourceDevice;
+        let mut policy_engine = Source::new_dual_role(driver, device, false);
         skip_to_ready(&mut policy_engine).await;
 
         simulate_sink_control_message(&mut policy_engine, ControlMessageType::PrSwap, 2);


### PR DESCRIPTION
Adds `dual_role.rs` and missing dual-role requirements for the `Sink`. Also makes changes to ownership for the `Sink` and `Source` drivers and device policy managers. Still need to write some tests and add examples.