### PR TITLE
feat: Make support for EPR behind a feature gate

### DIFF
--- a/usbpd/Cargo.toml
+++ b/usbpd/Cargo.toml
@@ -30,8 +30,9 @@ serde = { version = "1.0.228", default-features = false, features = [
 tokio = { version = "1.49.0", features = ["rt", "macros"] }
 
 [features]
-default = []
+default = ["epr"]
 
 log = ["dep:log"]
 defmt = ["dep:defmt", "heapless/defmt"]
 serde = ["dep:serde", "heapless/serde"]
+epr = []

--- a/usbpd/src/protocol_layer/message/data/mod.rs
+++ b/usbpd/src/protocol_layer/message/data/mod.rs
@@ -16,6 +16,7 @@ pub mod source_capabilities;
 
 pub mod sink_capabilities;
 
+#[cfg(feature = "epr")]
 pub mod epr_mode;
 
 // FIXME: add documentation
@@ -54,6 +55,7 @@ pub enum Data {
     /// Request for a power level from the source.
     Request(request::PowerSource),
     /// Used to enter, acknowledge or exit EPR mode.
+    #[cfg(feature = "epr")]
     EprMode(epr_mode::EprModeDataObject),
     /// Vendor defined messages (VDM).
     ///
@@ -102,6 +104,7 @@ impl Data {
                     }
                 }
             }
+            #[cfg(feature = "epr")]
             DataMessageType::EprRequest => {
                 let num_objects = message.header.num_objects();
                 trace!("EprRequest: num_objects={}, len={}", num_objects, len);
@@ -123,6 +126,7 @@ impl Data {
                     Data::Unknown
                 }
             }
+            #[cfg(feature = "epr")]
             DataMessageType::EprMode => {
                 if len != PDO_SIZE {
                     Data::Unknown
@@ -199,6 +203,7 @@ impl Data {
                     source_capabilities::PowerDataObject::VariableSupply(p) => p.0,
                     source_capabilities::PowerDataObject::Augmented(a) => match a {
                         source_capabilities::Augmented::Spr(p) => p.0,
+                        #[cfg(feature = "epr")]
                         source_capabilities::Augmented::Epr(p) => p.0,
                         source_capabilities::Augmented::Unknown(p) => *p,
                     },
@@ -208,6 +213,7 @@ impl Data {
                 2 * PDO_SIZE
             }
             Self::Request(_) => unimplemented!(),
+            #[cfg(feature = "epr")]
             Self::EprMode(epr_mode::EprModeDataObject(data_object)) => {
                 LittleEndian::write_u32(payload, *data_object);
                 PDO_SIZE

--- a/usbpd/src/protocol_layer/message/data/request.rs
+++ b/usbpd/src/protocol_layer/message/data/request.rs
@@ -351,6 +351,7 @@ impl PowerSource {
                         trace!("Skip PDO, voltage out of range. {:?}", augmented);
                     }
                 }
+                #[cfg(feature = "epr")]
                 source_capabilities::Augmented::Epr(avs) => {
                     if avs.min_voltage() <= voltage && avs.max_voltage() >= voltage {
                         return Some(IndexedAugmented(augmented, index));
@@ -477,6 +478,7 @@ impl PowerSource {
     ///
     /// Per USB PD 3.x Section 6.4.9, this creates an EPR_Request with an AVS RDO
     /// and a copy of the requested PDO.
+    #[cfg(feature = "epr")]
     pub fn new_epr_avs(
         current_request: CurrentRequest,
         voltage: ElectricPotential,

--- a/usbpd/src/protocol_layer/message/data/source_capabilities.rs
+++ b/usbpd/src/protocol_layer/message/data/source_capabilities.rs
@@ -61,6 +61,7 @@ impl PowerDataObject {
             PowerDataObject::VariableSupply(v) => v.0,
             PowerDataObject::Augmented(a) => match a {
                 Augmented::Spr(s) => s.0,
+                #[cfg(feature = "epr")]
                 Augmented::Epr(e) => e.0,
                 Augmented::Unknown(u) => *u,
             },
@@ -216,6 +217,7 @@ pub enum Augmented {
     /// SPR PPS
     Spr(SprProgrammablePowerSupply),
     /// EPR AVS
+    #[cfg(feature = "epr")]
     Epr(EprAdjustableVoltageSupply),
     /// Unknown
     Unknown(u32),
@@ -280,6 +282,7 @@ impl SprProgrammablePowerSupply {
     }
 }
 
+#[cfg(feature = "epr")]
 bitfield! {
     /// EPR AVS PDO
     #[derive(Clone, Copy, PartialEq, Eq)]
@@ -301,6 +304,7 @@ bitfield! {
     }
 }
 
+#[cfg(feature = "epr")]
 impl EprAdjustableVoltageSupply {
     /// The maximum voltage the PPS can be requested to supply
     pub fn max_voltage(&self) -> ElectricPotential {
@@ -389,6 +393,7 @@ impl SourceCapabilities {
     }
 
     /// Determine, whether the source is EPR mode capable.
+    #[cfg(feature = "epr")]
     pub fn epr_mode_capable(&self) -> bool {
         self.vsafe_5v().map(FixedSupply::epr_mode_capable).unwrap_or_default()
     }
@@ -402,6 +407,7 @@ impl SourceCapabilities {
     ///
     /// Per USB PD Spec R3.2 Section 6.5.15.1, EPR Capabilities Messages have
     /// SPR PDOs in positions 1-7 and EPR PDOs starting at position 8.
+    #[cfg(feature = "epr")]
     pub fn is_epr_capabilities(&self) -> bool {
         self.0.len() > 7
     }
@@ -429,6 +435,7 @@ impl SourceCapabilities {
     /// - Only valid in EPR Capabilities Messages
     ///
     /// Returns iterator of (position, PDO) tuples where position is 1-indexed (8, 9, 10, 11).
+    #[cfg(feature = "epr")]
     pub fn epr_pdos(&self) -> impl Iterator<Item = (u8, &PowerDataObject)> {
         self.0.iter().skip(7).enumerate().map(|(i, pdo)| ((i + 8) as u8, pdo))
     }
@@ -442,6 +449,7 @@ impl SourceCapabilities {
     /// EPR (A)PDOs per spec:
     /// - Fixed Supply PDOs offering 28V, 36V, or 48V (voltage > 20V)
     /// - EPR AVS APDOs
+    #[cfg(feature = "epr")]
     pub fn has_epr_pdo_in_spr_positions(&self) -> bool {
         let max_spr_voltage = ElectricPotential::new::<volt>(20);
         self.0.iter().take(7).any(|pdo| match pdo {
@@ -477,6 +485,7 @@ impl PdoKind for SourceCapabilities {
                 PowerDataObject::VariableSupply(_) => Some(Kind::VariableSupply),
                 PowerDataObject::Augmented(augmented) => match augmented {
                     Augmented::Spr(_) => Some(Kind::Pps),
+                    #[cfg(feature = "epr")]
                     Augmented::Epr(_) => Some(Kind::Avs),
                     Augmented::Unknown(_) => None,
                 },
@@ -509,6 +518,7 @@ pub fn parse_raw_pdo(raw: u32) -> PowerDataObject {
         0b10 => PowerDataObject::VariableSupply(VariableSupply(raw)),
         0b11 => PowerDataObject::Augmented(match AugmentedRaw(raw).supply() {
             0b00 => Augmented::Spr(SprProgrammablePowerSupply(raw)),
+            #[cfg(feature = "epr")]
             0b01 => Augmented::Epr(EprAdjustableVoltageSupply(raw)),
             x => {
                 warn!("Unknown AugmentedPowerDataObject supply {}", x);

--- a/usbpd/src/protocol_layer/message/extended/mod.rs
+++ b/usbpd/src/protocol_layer/message/extended/mod.rs
@@ -59,6 +59,7 @@ impl Extended {
                         PowerDataObject::VariableSupply(p) => p.0,
                         PowerDataObject::Augmented(a) => match a {
                             crate::protocol_layer::message::data::source_capabilities::Augmented::Spr(p) => p.0,
+                            #[cfg(feature = "epr")]
                             crate::protocol_layer::message::data::source_capabilities::Augmented::Epr(p) => p.0,
                             crate::protocol_layer::message::data::source_capabilities::Augmented::Unknown(p) => *p,
                         },

--- a/usbpd/src/protocol_layer/mod.rs
+++ b/usbpd/src/protocol_layer/mod.rs
@@ -26,6 +26,7 @@ use usbpd_traits::{Driver, DriverRxError, DriverTxError};
 
 use crate::PowerRole;
 use crate::counters::{Counter, CounterType, Error as CounterError};
+#[cfg(feature = "epr")]
 use crate::protocol_layer::message::data::epr_mode::EprModeDataObject;
 use crate::protocol_layer::message::data::source_capabilities::SourceCapabilities;
 use crate::protocol_layer::message::extended::Extended;
@@ -674,6 +675,7 @@ impl<DRIVER: Driver, TIMER: Timer> ProtocolLayer<DRIVER, TIMER> {
     }
 
     /// Transmit an EPR mode data message.
+    #[cfg(feature = "epr")]
     pub async fn transmit_epr_mode(
         &mut self,
         action: message::data::epr_mode::Action,
@@ -798,6 +800,7 @@ impl<DRIVER: Driver, TIMER: Timer> ProtocolLayer<DRIVER, TIMER> {
     ) -> Result<(), ProtocolError> {
         // Only sources can send capabilities
         debug_assert!(matches!(self.default_header.port_power_role(), PowerRole::Source));
+        #[cfg(feature = "epr")]
         if source_capabilities.has_epr_pdo_in_spr_positions() {
             return Err(ProtocolError::TxError(TxError::HardReset));
         }

--- a/usbpd/src/sink/device_policy_manager.rs
+++ b/usbpd/src/sink/device_policy_manager.rs
@@ -4,7 +4,9 @@
 //! or renegotiate the power contract.
 use core::future::Future;
 
-use crate::protocol_layer::message::data::{epr_mode, request, sink_capabilities, source_capabilities};
+use crate::protocol_layer::message::data::{request, sink_capabilities, source_capabilities};
+#[cfg(feature = "epr")]
+use crate::protocol_layer::message::data::epr_mode;
 use crate::units::Power;
 
 /// Events that the device policy manager can send to the policy engine.
@@ -18,6 +20,7 @@ pub enum Event {
     ///
     /// Sends EprGetSourceCap extended control message.
     /// See [8.3.3.8.1]
+    #[cfg(feature = "epr")]
     RequestEprSourceCapabilities,
     /// Enter EPR mode with the specified operational PDP.
     ///
@@ -28,12 +31,14 @@ pub enum Event {
     /// EPR Sink Operational PDP. For example, a 28V × 5A = 140W device should pass 140W.
     ///
     /// See spec Table 8.39: "Steps for Entering EPR Mode (Success)"
+    #[cfg(feature = "epr")]
     EnterEprMode(Power),
     /// Exit EPR mode (sink-initiated).
     ///
     /// Sends EPR_Mode (Exit) message to source, then waits for Source_Capabilities.
     /// After receiving caps, negotiation proceeds as normal SPR negotiation.
     /// See spec Table 8.46: "Steps for Exiting EPR Mode (Sink Initiated)"
+    #[cfg(feature = "epr")]
     ExitEprMode,
     /// Request a certain power level.
     RequestPower(request::PowerSource),
@@ -97,6 +102,7 @@ pub trait DevicePolicyManager {
     /// - EPR capable bit not set in RDO
     /// - Source unable to enter EPR mode (sink may retry later)
     /// - EPR capable bit not set in PDO
+    #[cfg(feature = "epr")]
     fn epr_mode_entry_failed(&mut self, _reason: epr_mode::DataEnterFailed) -> impl Future<Output = ()> {
         async {}
     }

--- a/usbpd/src/sink/policy_engine/mod.rs
+++ b/usbpd/src/sink/policy_engine/mod.rs
@@ -7,6 +7,7 @@ use usbpd_traits::Driver;
 
 use super::device_policy_manager::DevicePolicyManager;
 use crate::counters::Counter;
+#[cfg(feature = "epr")]
 use crate::protocol_layer::message::data::epr_mode::{self, Action};
 use crate::protocol_layer::message::data::request::PowerSource;
 use crate::protocol_layer::message::data::source_capabilities::SourceCapabilities;
@@ -67,11 +68,17 @@ enum State {
     GetSourceCap(Mode, request::PowerSource),
 
     // EPR states
+    #[cfg(feature = "epr")]
     EprModeEntry(request::PowerSource, units::Power),
+    #[cfg(feature = "epr")]
     EprEntryWaitForResponse(request::PowerSource),
+    #[cfg(feature = "epr")]
     EprWaitForCapabilities(request::PowerSource),
+    #[cfg(feature = "epr")]
     EprSendExit,
+    #[cfg(feature = "epr")]
     EprExitReceived(request::PowerSource),
+    #[cfg(feature = "epr")]
     EprKeepAlive(request::PowerSource),
 }
 
@@ -385,6 +392,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                                     State::EvaluateCapabilities(capabilities)
                                 }
                             }
+                            #[cfg(feature = "epr")]
                             MessageType::Extended(ExtendedMessageType::EprSourceCapabilities) => {
                                 if let Some(Payload::Extended(extended::Extended::EprSourceCapabilities(pdos))) =
                                     message.payload
@@ -403,6 +411,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                                     unreachable!()
                                 }
                             }
+                            #[cfg(feature = "epr")]
                             MessageType::Data(DataMessageType::EprMode) => {
                                 // Handle source exit notification.
                                 State::EprExitReceived(*power_source)
@@ -431,8 +440,11 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     // Event from device policy manager.
                     Either3::Second(event) => match event {
                         Event::RequestSprSourceCapabilities => State::GetSourceCap(Mode::Spr, *power_source),
+                        #[cfg(feature = "epr")]
                         Event::RequestEprSourceCapabilities => State::GetSourceCap(Mode::Epr, *power_source),
+                        #[cfg(feature = "epr")]
                         Event::EnterEprMode(pdp) => State::EprModeEntry(*power_source, pdp),
+                        #[cfg(feature = "epr")]
                         Event::ExitEprMode => State::EprSendExit,
                         Event::RequestPower(power_source) => State::SelectCapability(power_source),
                         Event::None => State::Ready(*power_source, false),
@@ -442,7 +454,10 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                         // PPS periodic timeout -> select capability again as keep-alive.
                         Either3::First(_) => State::SelectCapability(*power_source),
                         // EPR keep-alive timeout
+                        #[cfg(feature = "epr")]
                         Either3::Second(_) => State::EprKeepAlive(*power_source),
+                        #[cfg(not(feature = "epr"))]
+                        Either3::Second(_) => State::SelectCapability(*power_source),
                         // SinkRequest timeout -> re-request power after Wait response
                         Either3::Third(_) => State::SelectCapability(*power_source),
                     },
@@ -638,6 +653,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     State::Ready(*power_source, false)
                 }
             }
+            #[cfg(feature = "epr")]
             State::EprModeEntry(power_source, operational_pdp) => {
                 // Request entry into EPR mode.
                 // Per spec 8.3.3.26.2.1 (PE_SNK_Send_EPR_Mode_Entry), sink sends EPR_Mode (Enter)
@@ -689,6 +705,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     _ => State::SendSoftReset,
                 }
             }
+            #[cfg(feature = "epr")]
             State::EprEntryWaitForResponse(power_source) => {
                 // Wait for EnterSucceeded after receiving EnterAcknowledged.
                 // Per spec 8.3.3.26.2.2 (PE_SNK_EPR_Mode_Wait_For_Response), use SinkEPREnterTimer
@@ -721,6 +738,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     _ => State::SendSoftReset,
                 }
             }
+            #[cfg(feature = "epr")]
             State::EprWaitForCapabilities(_power_source) => {
                 // After successful EPR mode entry, source automatically sends EPR_Source_Capabilities.
                 // This may be a chunked extended message that requires assembly.
@@ -740,12 +758,14 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     }
                 }
             }
+            #[cfg(feature = "epr")]
             State::EprSendExit => {
                 // Inform partner we are exiting EPR.
                 self.protocol_layer.transmit_epr_mode(Action::Exit, 0).await?;
                 self.mode = Mode::Spr;
                 State::WaitForCapabilities
             }
+            #[cfg(feature = "epr")]
             State::EprExitReceived(power_source) => {
                 // Per USB PD Spec R3.2 Section 8.3.3.26.4.2 (PE_SNK_EPR_Mode_Exit_Received):
                 // - If in an Explicit Contract with an SPR (A)PDO → WaitForCapabilities
@@ -770,6 +790,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                     State::WaitForCapabilities
                 }
             }
+            #[cfg(feature = "epr")]
             State::EprKeepAlive(power_source) => {
                 // Per spec 8.3.3.3.11 (PE_SNK_EPR_Keep_Alive):
                 // - Entry: Send EPR_KeepAlive message, start SenderResponseTimer

--- a/usbpd/src/source/device_policy_manager.rs
+++ b/usbpd/src/source/device_policy_manager.rs
@@ -23,8 +23,10 @@ pub enum Event {
     /// Indicate a Vconn swap needs to be done
     RequestVconnSwap,
     /// **EPR** Get the Remote DRP's Source EPR capabilities
+    #[cfg(feature = "epr")]
     RequestEprSourceCapabilities,
     /// **EPR**
+    #[cfg(feature = "epr")]
     ExitEprMode,
     /// **DRP** Indicate a data swap needs to be done
     RequestDataRoleSwap,

--- a/usbpd/src/source/policy_engine/mod.rs
+++ b/usbpd/src/source/policy_engine/mod.rs
@@ -9,7 +9,9 @@ use crate::counters::Counter;
 use crate::protocol_layer::message::data::request::PowerSource;
 use crate::protocol_layer::message::data::sink_capabilities::SinkCapabilities;
 use crate::protocol_layer::message::data::source_capabilities::{Kind, SourceCapabilities};
-use crate::protocol_layer::message::data::{Data, PdoKind, epr_mode, request};
+use crate::protocol_layer::message::data::{Data, PdoKind, request};
+#[cfg(feature = "epr")]
+use crate::protocol_layer::message::data::epr_mode;
 use crate::protocol_layer::message::extended::Extended;
 use crate::protocol_layer::message::extended::extended_control::ExtendedControlMessageType;
 use crate::protocol_layer::message::header::{
@@ -80,6 +82,7 @@ enum State {
     // 8.3.3.20 Vconn Swap
     VconnSwap { source: VcsSwapSource, state: VcsState },
     // 8.3.3.26 EPR States
+    #[cfg(feature = "epr")]
     EprMode(EprState),
     // Custom state to signal exit out of source to sink from a power swap
     PrSwapToSinkStartup,
@@ -134,6 +137,7 @@ enum FastPowerRoleSwap {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum VcsSwapSource {
     Message,
+    #[cfg(feature = "epr")]
     Epr,
 }
 
@@ -154,6 +158,7 @@ enum VcsState {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg(feature = "epr")]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum EprState {
     Entry,
@@ -504,7 +509,9 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
                         Event::UpdatedSourceCapabilities => State::SendCapabilities,
                         Event::RequestSinkCapabilities => State::GetSinkCap,
                         Event::RequestSourceCapabilities => State::DrpGetSourceCap(Mode::Spr),
+                        #[cfg(feature = "epr")]
                         Event::RequestEprSourceCapabilities => State::DrpGetSourceCap(Mode::Epr),
+                        #[cfg(feature = "epr")]
                         Event::ExitEprMode => State::EprMode(EprState::SendExit),
                         Event::RequestVconnSwap => State::VconnSwap {
                             source: VcsSwapSource::Message,
@@ -812,6 +819,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
 
             // 8.3.3.26 EPR States
             // FIXME: Source EPR
+            #[cfg(feature = "epr")]
             State::EprMode(state) => self.execute_epr_state(*state).await?,
 
             // 8.3.3.28.1
@@ -1091,6 +1099,9 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
                 self.protocol_layer
                     .transmit_control_message(ControlMessageType::Reject)
                     .await?;
+                #[cfg(not(feature = "epr"))]
+                {Ok(State::Ready)}
+                #[cfg(feature = "epr")]
                 match source {
                     VcsSwapSource::Message => Ok(State::Ready),
                     VcsSwapSource::Epr => Ok(State::EprMode(EprState::DiscoverCable)),
@@ -1113,6 +1124,9 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
                     .drive_vconn(false)
                     .await
                     .map_err(|_| Error::ReconnectionRequired)?;
+                #[cfg(not(feature = "epr"))]
+                {Ok(State::Ready)}
+                #[cfg(feature = "epr")]
                 match source {
                     VcsSwapSource::Message => Ok(State::Ready),
                     VcsSwapSource::Epr => Ok(State::EprMode(EprState::DiscoverCable)),
@@ -1134,6 +1148,9 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
                 self.protocol_layer
                     .transmit_control_message(ControlMessageType::PsRdy)
                     .await?;
+                #[cfg(not(feature = "epr"))]
+                {Ok(State::Ready)}
+                #[cfg(feature = "epr")]
                 match source {
                     VcsSwapSource::Message => Ok(State::Ready),
                     VcsSwapSource::Epr => Ok(State::EprMode(EprState::DiscoverCable)),
@@ -1145,6 +1162,9 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
                     .drive_vconn(true)
                     .await
                     .map_err(|_| Error::ReconnectionRequired)?;
+                #[cfg(not(feature = "epr"))]
+                {Ok(State::Ready)}
+                #[cfg(feature = "epr")]
                 match source {
                     VcsSwapSource::Message => Ok(State::Ready),
                     VcsSwapSource::Epr => Ok(State::EprMode(EprState::DiscoverCable)),
@@ -1154,6 +1174,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
     }
 
     // 8.3.3.26 EPR States
+    #[cfg(feature = "epr")]
     async fn execute_epr_state(&mut self, state: EprState) -> Result<State, Error> {
         match state {
             // 8.3.3.26.1.1 (PE_SRC_Evaluate_EPR_Mode_Entry):
@@ -1263,6 +1284,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
                 State::NegotiateCapability(power_source)
             }
 
+            #[cfg(feature = "epr")]
             MessageType::Data(DataMessageType::EprRequest) => {
                 if self.mode != Mode::Epr {
                     return Err(Error::Protocol(ProtocolError::RxError(RxError::HardReset)));
@@ -1275,6 +1297,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: SourceDpm> Source<DRIVER, TIMER, DPM> {
                 State::NegotiateCapability(power_source)
             }
 
+            #[cfg(feature = "epr")]
             MessageType::Data(DataMessageType::EprMode) => match message.payload {
                 Some(Payload::Data(Data::EprMode(epr_data))) => match epr_data.action() {
                     epr_mode::Action::Enter => match self.mode {


### PR DESCRIPTION
I have started the work on #40 to see if EPR support can be disabled. ~On my STM32G071 it saves about 2.7 kb flash~.

Update, running `cargo size --target thumbv6m-none-eabi --release` with or without EPR support:
```
   text    data     bss     dec     hex filename
 102788      80    6800  109668   1ac64 firmware
```
```
   text    data     bss     dec     hex filename
 107548      80    6808  114436   1bf04 firmware
```
That is a 4.7 kb saved flash when EPR is not needed.