### PR TITLE
Remove `uom` dependency, move towards our own unit definitions

### DIFF
--- a/usbpd/Cargo.toml
+++ b/usbpd/Cargo.toml
@@ -16,7 +16,6 @@ usbpd-traits.workspace = true
 proc-bitfield.workspace = true
 byteorder.workspace = true
 heapless.workspace = true
-uom = { workspace = true, features = ["si", "u32"] }
 embassy-futures.workspace = true
 
 thiserror = { workspace = true }

--- a/usbpd/src/lib.rs
+++ b/usbpd/src/lib.rs
@@ -17,9 +17,6 @@
 #![cfg_attr(not(test), no_std)]
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate uom;
-
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;
 
@@ -33,66 +30,54 @@ pub mod timers;
 #[allow(missing_docs)] // FIXME: Docs for the dummy?
 pub mod dummy;
 
-/// This module defines the CGS (centimeter-gram-second) unit system
-/// for use in the USB Power Delivery Protocol layer. These units are
-/// defined using the `uom` (units of measurement) library and are
-/// expressed as `u32` values for milliamps, millivolts, and microwatts.
+/// This module defines the unit system for use in the USB Power Delivery
+/// Protocol layer. These units are expressed as `u32` values for milliamps,
+/// millivolts, and microwatts.
 pub mod units {
-    ISQ!(
-        uom::si,
-        u32,
-        (millimeter, kilogram, second, milliampere, kelvin, mole, candela)
-    );
-}
 
-/// Defines a unit for electric current in 50 mA steps.
-pub mod _50milliamperes_mod {
-    unit! {
-        system: uom::si;
-        quantity: uom::si::electric_current;
+    /// Electric potential in mV
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct ElectricPotential(u32);
 
-        @_50milliamperes: 0.05; "_50mA", "_50milliamps", "_50milliamps";
+    impl ElectricPotential {
+        /// Create a new electric potential, given in millivolts
+        pub fn new_mv(mv: u32) -> Self {
+            Self(mv)
+        }
+        /// Get the electric potential in millivolts
+        pub fn get_mv(&self) -> u32 {
+            self.0
+        }
     }
-}
 
-/// Defines a unit for electric potential in 50 mV steps.
-pub mod _50millivolts_mod {
-    unit! {
-        system: uom::si;
-        quantity: uom::si::electric_potential;
+    /// Electric current in mA
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct ElectricCurrent(u32);
 
-        @_50millivolts: 0.05; "_50mV", "_50millivolts", "_50millivolts";
+    impl ElectricCurrent {
+        /// Create a new electric current, given in milliamps
+        pub fn new_ma(ma: u32) -> Self {
+            Self(ma)
+        }
+        /// Get the electric current in milliamps
+        pub fn get_ma(&self) -> u32 {
+            self.0
+        }
     }
-}
 
-/// Defines a unit for electric potential in 20 mV steps.
-pub mod _20millivolts_mod {
-    unit! {
-        system: uom::si;
-        quantity: uom::si::electric_potential;
+    /// Electric power in mW
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Power(u32);
 
-        @_20millivolts: 0.02; "_20mV", "_20millivolts", "_20millivolts";
-    }
-}
-
-/// Defines a unit for electric potential in 25 mV steps.
-/// Used by AVS (Adjustable Voltage Supply) per USB PD 3.2 Table 6.26.
-pub mod _25millivolts_mod {
-    unit! {
-        system: uom::si;
-        quantity: uom::si::electric_potential;
-
-        @_25millivolts: 0.025; "_25mV", "_25millivolts", "_25millivolts";
-    }
-}
-
-/// Defines a unit for power in 250 mW steps.
-pub mod _250milliwatts_mod {
-    unit! {
-        system: uom::si;
-        quantity: uom::si::power;
-
-        @_250milliwatts: 0.25; "_250mW", "_250milliwatts", "_250milliwatts";
+    impl Power {
+        /// Create a new electric power, given in milliwatts
+        pub fn new_mw(mw: u32) -> Self {
+            Self(mw)
+        }
+        /// Get the electric power in milliwatts
+        pub fn get_mw(&self) -> u32 {
+            self.0
+        }
     }
 }
 

--- a/usbpd/src/lib.rs
+++ b/usbpd/src/lib.rs
@@ -74,6 +74,10 @@ pub mod units {
         pub fn new_mw(mw: u32) -> Self {
             Self(mw)
         }
+        /// Create a new electric power, from current and potential
+        pub fn from_current_and_potential(current: ElectricCurrent, potential: ElectricPotential) -> Self {
+            Self(current.get_ma() * potential.get_mv() / 1000)
+        }
         /// Get the electric power in milliwatts
         pub fn get_mw(&self) -> u32 {
             self.0

--- a/usbpd/src/protocol_layer/message/data/request.rs
+++ b/usbpd/src/protocol_layer/message/data/request.rs
@@ -1,15 +1,9 @@
 //! Definitions of request data message content.
 use byteorder::{ByteOrder, LittleEndian};
 use proc_bitfield::bitfield;
-use uom::si::electric_current::{self, centiampere};
-use uom::si::{self};
 
 use super::source_capabilities;
-use crate::_20millivolts_mod::_20millivolts;
-use crate::_25millivolts_mod::_25millivolts;
-use crate::_50milliamperes_mod::_50milliamperes;
-use crate::_250milliwatts_mod::_250milliwatts;
-use crate::units::{ElectricCurrent, ElectricPotential};
+use crate::units::{ElectricCurrent, ElectricPotential, Power};
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq)]
@@ -49,11 +43,11 @@ impl FixedVariableSupply {
     }
 
     pub fn operating_current(&self) -> ElectricCurrent {
-        ElectricCurrent::new::<centiampere>(self.raw_operating_current().into())
+        ElectricCurrent::new_ma(self.raw_operating_current() as u32 * 10)
     }
 
     pub fn max_operating_current(&self) -> ElectricCurrent {
-        ElectricCurrent::new::<centiampere>(self.raw_max_operating_current().into())
+        ElectricCurrent::new_ma(self.raw_max_operating_current() as u32 * 10)
     }
 }
 
@@ -90,12 +84,12 @@ impl Battery {
         LittleEndian::write_u32(buf, self.0);
     }
 
-    pub fn operating_power(&self) -> si::u32::Power {
-        si::u32::Power::new::<_250milliwatts>(self.raw_operating_power().into())
+    pub fn operating_power(&self) -> Power {
+        Power::new_mw(self.raw_operating_power() as u32 * 250)
     }
 
-    pub fn max_operating_power(&self) -> si::u32::Power {
-        si::u32::Power::new::<_250milliwatts>(self.raw_max_operating_power().into())
+    pub fn max_operating_power(&self) -> Power {
+        Power::new_mw(self.raw_max_operating_power() as u32 * 250)
     }
 }
 
@@ -132,11 +126,11 @@ impl Pps {
     }
 
     pub fn output_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_20millivolts>(self.raw_output_voltage().into())
+        ElectricPotential::new_mv(self.raw_output_voltage() as u32 * 20)
     }
 
     pub fn operating_current(&self) -> ElectricCurrent {
-        ElectricCurrent::new::<_50milliamperes>(self.raw_operating_current().into())
+        ElectricCurrent::new_ma(self.raw_operating_current() as u32 * 50)
     }
 }
 
@@ -175,11 +169,11 @@ impl Avs {
     }
 
     pub fn output_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_25millivolts>(self.raw_output_voltage().into())
+        ElectricPotential::new_mv(self.raw_output_voltage() as u32 * 25)
     }
 
     pub fn operating_current(&self) -> ElectricCurrent {
-        ElectricCurrent::new::<_50milliamperes>(self.raw_operating_current().into())
+        ElectricCurrent::new_ma(self.raw_operating_current() as u32 * 50)
     }
 }
 
@@ -380,7 +374,7 @@ impl PowerSource {
             CurrentRequest::Specific(x) => (x, x > pdo.max_current()),
         };
 
-        let mut raw_current = current.get::<electric_current::centiampere>() as u16;
+        let mut raw_current = (current.get_ma() / 10) as u16;
 
         if raw_current > 0x3ff {
             error!("Clamping invalid current: {} mA", 10 * raw_current);
@@ -450,14 +444,14 @@ impl PowerSource {
             CurrentRequest::Specific(x) => (x, x > max_current),
         };
 
-        let mut raw_current = current.get::<_50milliamperes>() as u16;
+        let mut raw_current = (current.get_ma() / 50) as u16;
 
         if raw_current > 0x3ff {
             error!("Clamping invalid current: {} mA", 10 * raw_current);
             raw_current = 0x3ff;
         }
 
-        let raw_voltage = voltage.get::<_20millivolts>() as u16;
+        let raw_voltage = (voltage.get_mv() / 20) as u16;
 
         let object_position = index + 1;
         assert!(object_position > 0b0000 && object_position <= 0b1110);
@@ -490,7 +484,9 @@ impl PowerSource {
 
         let IndexedAugmented(pdo, index) = selected.unwrap();
         let max_current = match pdo {
-            source_capabilities::Augmented::Epr(avs) => avs.pd_power() / voltage,
+            source_capabilities::Augmented::Epr(avs) => {
+                ElectricCurrent::new_ma(avs.pd_power().get_mw() * 1000 / voltage.get_mv())
+            }
             _ => return Err(Error::VoltageMismatch),
         };
 
@@ -499,7 +495,7 @@ impl PowerSource {
             CurrentRequest::Specific(x) => (x, x > max_current),
         };
 
-        let mut raw_current = current.get::<_50milliamperes>() as u16;
+        let mut raw_current = (current.get_ma() / 50) as u16;
 
         if raw_current > 0x7f {
             error!("Clamping invalid AVS current: {} mA", 50 * raw_current);
@@ -509,7 +505,7 @@ impl PowerSource {
         // AVS voltage is in 25 mV units with LSB 2 bits = 0 (effective 100 mV steps)
         // Per USB PD 3.2 Table 6.26: "Output voltage in 25 mV units,
         // the least two significant bits Shall be set to zero"
-        let raw_voltage = (voltage.get::<_25millivolts>() as u16) & !0x3;
+        let raw_voltage = (voltage.get_mv() / 25) as u16 & !0x3;
 
         let object_position = index + 1;
         assert!(object_position > 0b0000 && object_position <= 0b1110);

--- a/usbpd/src/protocol_layer/message/data/sink_capabilities.rs
+++ b/usbpd/src/protocol_layer/message/data/sink_capabilities.rs
@@ -5,10 +5,7 @@
 //! contains Power Data Objects describing what power levels the sink can operate at.
 use heapless::Vec;
 use proc_bitfield::bitfield;
-use uom::si::electric_current::centiampere;
 
-use crate::_50millivolts_mod::_50millivolts;
-use crate::_250milliwatts_mod::_250milliwatts;
 use crate::units::{ElectricCurrent, ElectricPotential, Power};
 
 /// Fast Role Swap required USB Type-C current.
@@ -99,12 +96,12 @@ impl FixedSupply {
 
     /// Get the voltage in standard units.
     pub fn voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_50millivolts>(self.raw_voltage().into())
+        ElectricPotential::new_mv(self.raw_voltage() as u32 * 50)
     }
 
     /// Get the operational current in standard units.
     pub fn operational_current(&self) -> ElectricCurrent {
-        ElectricCurrent::new::<centiampere>(self.raw_operational_current().into())
+        ElectricCurrent::new_ma(self.raw_operational_current() as u32 * 10)
     }
 
     /// Get the Fast Role Swap required current.
@@ -144,17 +141,17 @@ impl Battery {
 
     /// Get the maximum voltage in standard units.
     pub fn max_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_50millivolts>(self.raw_max_voltage().into())
+        ElectricPotential::new_mv(self.raw_max_voltage() as u32 * 50)
     }
 
     /// Get the minimum voltage in standard units.
     pub fn min_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_50millivolts>(self.raw_min_voltage().into())
+        ElectricPotential::new_mv(self.raw_min_voltage() as u32 * 50)
     }
 
     /// Get the operational power in standard units.
     pub fn operational_power(&self) -> Power {
-        Power::new::<_250milliwatts>(self.raw_operational_power().into())
+        Power::new_mw(self.raw_operational_power() as u32 * 250)
     }
 }
 
@@ -196,17 +193,17 @@ impl VariableSupply {
 
     /// Get the maximum voltage in standard units.
     pub fn max_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_50millivolts>(self.raw_max_voltage().into())
+        ElectricPotential::new_mv(self.raw_max_voltage() as u32 * 50)
     }
 
     /// Get the minimum voltage in standard units.
     pub fn min_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_50millivolts>(self.raw_min_voltage().into())
+        ElectricPotential::new_mv(self.raw_min_voltage() as u32 * 50)
     }
 
     /// Get the operational current in standard units.
     pub fn operational_current(&self) -> ElectricCurrent {
-        ElectricCurrent::new::<centiampere>(self.raw_operational_current().into())
+        ElectricCurrent::new_ma(self.raw_operational_current() as u32 * 10)
     }
 }
 

--- a/usbpd/src/protocol_layer/message/data/source_capabilities.rs
+++ b/usbpd/src/protocol_layer/message/data/source_capabilities.rs
@@ -1,14 +1,8 @@
 //! Definitions of source capabilities data message content.
 use heapless::Vec;
 use proc_bitfield::bitfield;
-use uom::si::electric_current::centiampere;
-use uom::si::electric_potential::{decivolt, volt};
-use uom::si::power::watt;
 
 use super::PdoKind;
-use crate::_50milliamperes_mod::_50milliamperes;
-use crate::_50millivolts_mod::_50millivolts;
-use crate::_250milliwatts_mod::_250milliwatts;
 use crate::units::{ElectricCurrent, ElectricPotential, Power};
 
 /// Kinds of supplies that can be reported within source capabilities.
@@ -123,12 +117,12 @@ impl Default for FixedSupply {
 impl FixedSupply {
     /// Voltage of the Fixed Supply
     pub fn voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_50millivolts>(self.raw_voltage().into())
+        ElectricPotential::new_mv(self.raw_voltage() as u32 * 50)
     }
 
     /// Maximum current of the Fixed Supply
     pub fn max_current(&self) -> ElectricCurrent {
-        ElectricCurrent::new::<centiampere>(self.raw_max_current().into())
+        ElectricCurrent::new_ma(self.raw_max_current() as u32 * 10)
     }
 
     /// Create a new Fixed Supply at vSafe5V with the rated current
@@ -160,17 +154,17 @@ bitfield! {
 impl Battery {
     /// The maximum voltage the battery can supply
     pub fn max_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_50millivolts>(self.raw_max_voltage().into())
+        ElectricPotential::new_mv(self.raw_max_voltage() as u32 * 50)
     }
 
     /// The minimum voltage the battery can supply
     pub fn min_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_50millivolts>(self.raw_min_voltage().into())
+        ElectricPotential::new_mv(self.raw_min_voltage() as u32 * 50)
     }
 
     /// The maximum power the battery can supply
     pub fn max_power(&self) -> Power {
-        Power::new::<_250milliwatts>(self.raw_max_power().into())
+        Power::new_mw(self.raw_max_power() as u32 * 250)
     }
 }
 
@@ -194,17 +188,17 @@ bitfield! {
 impl VariableSupply {
     /// The maximum voltage the variable supply is capable of
     pub fn max_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_50millivolts>(self.raw_max_voltage().into())
+        ElectricPotential::new_mv(self.raw_max_voltage() as u32 * 50)
     }
 
     /// The minimum voltage the variable supply is capable of
     pub fn min_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<_50millivolts>(self.raw_min_voltage().into())
+        ElectricPotential::new_mv(self.raw_min_voltage() as u32 * 50)
     }
 
     /// The maximum current the variable supply can offer
     pub fn max_current(&self) -> ElectricCurrent {
-        ElectricCurrent::new::<centiampere>(self.raw_max_current().into())
+        ElectricCurrent::new_ma(self.raw_max_current() as u32 * 10)
     }
 }
 
@@ -266,17 +260,17 @@ impl Default for SprProgrammablePowerSupply {
 impl SprProgrammablePowerSupply {
     /// The maximum voltage the PPS can be requested to supply
     pub fn max_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<decivolt>(self.raw_max_voltage().into())
+        ElectricPotential::new_mv(self.raw_max_voltage() as u32 * 100)
     }
 
     /// The minimum voltage the PPS can be requested to supply
     pub fn min_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<decivolt>(self.raw_min_voltage().into())
+        ElectricPotential::new_mv(self.raw_min_voltage() as u32 * 100)
     }
 
     /// The maximum current the PPS can supply.
     pub fn max_current(&self) -> ElectricCurrent {
-        ElectricCurrent::new::<_50milliamperes>(self.raw_max_current().into())
+        ElectricCurrent::new_ma(self.raw_max_current() as u32 * 50)
     }
 }
 
@@ -304,17 +298,17 @@ bitfield! {
 impl EprAdjustableVoltageSupply {
     /// The maximum voltage the PPS can be requested to supply
     pub fn max_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<decivolt>(self.raw_max_voltage().into())
+        ElectricPotential::new_mv(self.raw_max_voltage() as u32 * 100)
     }
 
     /// The minimum voltage the PPS can be requested to supply
     pub fn min_voltage(&self) -> ElectricPotential {
-        ElectricPotential::new::<decivolt>(self.raw_min_voltage().into())
+        ElectricPotential::new_mv(self.raw_min_voltage() as u32 * 100)
     }
 
     /// Rated power the PPS can supply
     pub fn pd_power(&self) -> Power {
-        Power::new::<watt>(self.raw_pd_power().into())
+        Power::new_mw(self.raw_pd_power() as u32 * 1000)
     }
 }
 
@@ -443,7 +437,7 @@ impl SourceCapabilities {
     /// - Fixed Supply PDOs offering 28V, 36V, or 48V (voltage > 20V)
     /// - EPR AVS APDOs
     pub fn has_epr_pdo_in_spr_positions(&self) -> bool {
-        let max_spr_voltage = ElectricPotential::new::<volt>(20);
+        let max_spr_voltage = ElectricPotential::new_mv(20_000);
         self.0.iter().take(7).any(|pdo| match pdo {
             // EPR Fixed Supply: voltage > 20V
             PowerDataObject::FixedSupply(f) => f.voltage() > max_spr_voltage,

--- a/usbpd/src/sink/policy_engine/mod.rs
+++ b/usbpd/src/sink/policy_engine/mod.rs
@@ -2,7 +2,6 @@
 use core::marker::PhantomData;
 
 use embassy_futures::select::{Either3, select3};
-use uom::si::power::watt;
 use usbpd_traits::Driver;
 
 use super::device_policy_manager::DevicePolicyManager;
@@ -651,7 +650,7 @@ impl<DRIVER: Driver, TIMER: Timer, DPM: DevicePolicyManager> Sink<DRIVER, TIMER,
                 // SinkEPREnterTimer (500ms) in EprEntryWaitForResponse. This means the total
                 // timeout could be ~530ms instead of 500ms in edge cases. However, this is
                 // within the spec's allowed range (tEnterEPR max = 550ms per Table 6.71).
-                let pdp_watts: u8 = operational_pdp.get::<watt>() as u8;
+                let pdp_watts: u8 = (operational_pdp.get_mw() / 1000) as u8;
                 self.protocol_layer.transmit_epr_mode(Action::Enter, pdp_watts).await?;
 
                 // Wait for EnterAcknowledged with SenderResponseTimer (spec step 9-14)


### PR DESCRIPTION
This removes the uom dependency by adding our own "unit wrappers".

`uom` requires floating point for unit definitions, which leads to a large binary increase in targets without hardware floating point. 

Initially I had helper functions for the different conversions, but I felt they didn't make the code clearer.

Closes #52